### PR TITLE
Support privateuse1_runtime activities

### DIFF
--- a/tb_plugin/torch_tb_profiler/profiler/trace.py
+++ b/tb_plugin/torch_tb_profiler/profiler/trace.py
@@ -43,6 +43,7 @@ EventTypeMap = {
     'operator': EventTypes.OPERATOR,
     'runtime': EventTypes.RUNTIME,
     'cuda_runtime': EventTypes.RUNTIME, # Support new Kineto naming convention
+    'privateuse1_runtime': EventTypes.RUNTIME,
     'kernel': EventTypes.KERNEL,
     'memcpy': EventTypes.MEMCPY,
     'gpu_memcpy': EventTypes.MEMCPY,


### PR DESCRIPTION
In PR https://github.com/IBM/kineto-spyre/pull/4 we start using the activity type `privateuse1_runtime`. This was already provided by Kineto, but support was never added to TB.