### PR TITLE
Fix flow event creation

### DIFF
--- a/libkineto/src/plugin/aiupti/AiuptiActivityHandlers.cpp
+++ b/libkineto/src/plugin/aiupti/AiuptiActivityHandlers.cpp
@@ -199,8 +199,12 @@ void AiuptiActivityProfilerSession::handleRuntimeActivity(
   runtime_activity->device = activity->process_id;
   runtime_activity->resource = systemThreadId();
   runtime_activity->threadId = threadId();
-  // TODO: verify the flow logic
-  runtime_activity->flow.id = activity->correlation_id;
+  // only enable outgoing flow for launch control block runtime activities
+  if (activity->cbid == AIUPTI_RUNTIME_TRACE_CBID_LAUNCH_CB_CMPT) {
+    runtime_activity->flow.id = activity->correlation_id;
+  } else {
+    runtime_activity->flow.id = 0;
+  }
   runtime_activity->flow.type = libkineto::kLinkAsyncCpuGpu;
   runtime_activity->flow.start =
       bool(std::find(correlateRuntimeOps_.begin(), correlateRuntimeOps_.end(),
@@ -366,7 +370,7 @@ void AiuptiActivityProfilerSession::handleMemcpyActivity(
   memcpy_activity->device = activity->device_id;
   memcpy_activity->resource = getResourceId(activity);
   memcpy_activity->threadId = activity->stream_id;
-  memcpy_activity->flow.id = activity->correlation_id;
+  memcpy_activity->flow.id = 0;
   memcpy_activity->flow.type = libkineto::kLinkAsyncCpuGpu;
   memcpy_activity->flow.start = 0;
   memcpy_activity->linked = linked;
@@ -429,7 +433,7 @@ void AiuptiActivityProfilerSession::handleMemoryActivity(
     mem_activity->device = activity->device_id;
     mem_activity->resource = getResourceId(activity);
     mem_activity->threadId = activity->stream_id;
-    mem_activity->flow.id = activity->correlation_id;
+    mem_activity->flow.id = 0;
     mem_activity->flow.type = libkineto::kLinkAsyncCpuGpu;
     mem_activity->flow.start = 0;
     mem_activity->linked = linked;
@@ -567,7 +571,7 @@ void AiuptiActivityProfilerSession::handleMemsetActivity(
   // This prevents us from using getResourceId which handles overlap
   memset_activity->resource = getBaseResourceId(activity);
   memset_activity->threadId = activity->stream_id;
-  memset_activity->flow.id = activity->correlation_id;
+  memset_activity->flow.id = 0;
   memset_activity->flow.type = libkineto::kLinkAsyncCpuGpu;
   memset_activity->flow.start = 0;
   memset_activity->linked = linked;

--- a/libkineto/src/plugin/aiupti/AiuptiActivityProfiler.cpp
+++ b/libkineto/src/plugin/aiupti/AiuptiActivityProfiler.cpp
@@ -9,8 +9,8 @@ uint32_t AiuptiActivityProfilerSession::iterationCount_ = 0;
 std::vector<std::array<unsigned char, 16>>
     AiuptiActivityProfilerSession::deviceUUIDs_ = {};
 std::vector<std::string> AiuptiActivityProfilerSession::correlateRuntimeOps_ = {
-    "launchCb",
-    "launchComputeStream"};
+    "aiuLaunchControlBlocks"
+  };
 
 // =========== Session Constructor ============= //
 AiuptiActivityProfilerSession::AiuptiActivityProfilerSession(


### PR DESCRIPTION
This addresses the first steps for fixing flow events for output traces as outlined in this [issue](https://github.ibm.com/ai-chip-toolchain/aiu-perf-toolkit/issues/516):

> 1. Update `correlateRuntimeOps_` to include `aiuLaunchControlBlocks` only
>    - This will allow Kineto to create flow starts for `aiuLaunchControlBlocks`
> 2. Update `flow.id` to be `0` for all activities that are not `aiuLaunchControlBlocks` or kernels
>    - This prevents undesired flows from being created
> 3. The result of steps 1 and 2 will be trace files with one start flow event per `aiuLaunchControlBlocks` and an end flow event for every kernel
>    - This results in a one-to-many relationship between the `aiuLaunchControlBlocks` and all kernels within the same super node. This is not supported by the [trace event format](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview?tab=t.0#heading=h.yr4qxyxotyw) when they share the same flow ID
>       - The trace will still load, but only one outgoing flow event per `aiuLaunchControlBlocks` will be shown
>       - We can resolve this with the Acelyzer/TensorBoard integration