### PR TITLE
fix recording of memory allocations

### DIFF
--- a/libkineto/src/plugin/aiupti/AiuptiActivityHandlers.cpp
+++ b/libkineto/src/plugin/aiupti/AiuptiActivityHandlers.cpp
@@ -477,29 +477,30 @@ void AiuptiActivityProfilerSession::handleMemoryActivity(
   traceBuffer_.emplace_activity(
     traceBuffer_.span, ActivityType::CPU_INSTANT_EVENT,
     "[memory]");
-    auto &memory_event = traceBuffer_.activities.back();
+  auto &memory_event = traceBuffer_.activities.back();
 
-    memory_event->startTime = activity->start;
+  memory_event->startTime = activity->start;
 
-    // Following convention where all memory events are put on the
-    // CPU thread. "Device Type" will denote CPU vs. AIU memory events
-    // 0 (CPU), 1 (AIU)
-    memory_event->device = systemThreadId();
-    memory_event->resource = systemThreadId();
+  // Following convention where all memory events are put on the
+  // CPU thread. "Device Type" will denote CPU vs. AIU memory events
+  // 0 (CPU), 1 (AIU)
+  memory_event->device = systemThreadId();
+  memory_event->resource = systemThreadId();
 
-    int64_t bytes = static_cast<int64_t>(activity->bytes);
-    if (activity->memory_operation_type == AIUPTI_ACTIVITY_MEMORY_OPERATION_TYPE_RELEASE) {
-      bytes *= -1;
-    }
-    totalAllocatedBytes_ += bytes;
-    memory_event->addMetadata("Total Reserved", 0);
-    memory_event->addMetadata("Total Allocated", totalAllocatedBytes_);
-    memory_event->addMetadata("Bytes", bytes);
-    memory_event->addMetadata("Addr", activity->address);
-    memory_event->addMetadata("Device Id", activity->device_id);
-    memory_event->addMetadata("Device Type", 1);
+  int64_t bytes = static_cast<int64_t>(activity->bytes);
 
-    memory_event->log(*logger);
+  // Negate the bytes since this is a memory release
+  bytes *= -1;
+  
+  totalAllocatedBytes_ += bytes;
+  memory_event->addMetadata("Total Reserved", 0);
+  memory_event->addMetadata("Total Allocated", totalAllocatedBytes_);
+  memory_event->addMetadata("Bytes", bytes);
+  memory_event->addMetadata("Addr", activity->address);
+  memory_event->addMetadata("Device Id", activity->device_id);
+  memory_event->addMetadata("Device Type", 1);
+
+  memory_event->log(*logger);
 }
 
 // inline std::string memcpyName(pti_view_memcpy_type kind,
@@ -604,6 +605,33 @@ void AiuptiActivityProfilerSession::handleMemsetActivity(
   //   return;
   // }
   memset_activity->log(*logger);
+
+  // Create event for AIU memory view
+  traceBuffer_.span.opCount += 1;
+  traceBuffer_.emplace_activity(
+    traceBuffer_.span, ActivityType::CPU_INSTANT_EVENT,
+    "[memory]");
+  auto &memory_event = traceBuffer_.activities.back();
+
+  memory_event->startTime = activity->start;
+
+  // Following convention where all memory events are put on the
+  // CPU thread. "Device Type" will denote CPU vs. AIU memory events
+  // 0 (CPU), 1 (AIU)
+  memory_event->device = systemThreadId();
+  memory_event->resource = systemThreadId();
+
+  int64_t bytes = static_cast<int64_t>(activity->bytes);
+  
+  totalAllocatedBytes_ += bytes;
+  memory_event->addMetadata("Total Reserved", 0);
+  memory_event->addMetadata("Total Allocated", totalAllocatedBytes_);
+  memory_event->addMetadata("Bytes", bytes);
+  memory_event->addMetadata("Addr", activity->address);
+  memory_event->addMetadata("Device Id", activity->device_id);
+  memory_event->addMetadata("Device Type", 1);
+
+  memory_event->log(*logger);
 }
 
 void AiuptiActivityProfilerSession::handlePtiActivity(

--- a/scripts/build_pytorch.sh
+++ b/scripts/build_pytorch.sh
@@ -8,7 +8,7 @@ ARCH="$(uname -m)"
 # ------------------------
 
 PYTORCH_VERSION="2.10.0"
-KINETO_VERSION="1.1.1"
+KINETO_VERSION="1.1.2"
 PYTORCH_BUILD_SUFFIX="+aiu.kineto."$KINETO_VERSION
 CONDA_ENV_NAME="buildenv-torch"
 CONDA_DIR="$HOME/miniconda"


### PR DESCRIPTION
**IMPORTANT: If we merge https://github.com/IBM/kineto-spyre/pull/16 then we should change this PR to merge into main and not branch torch-2.10.0**

When we made the switch from `Memory (allocation)` to `Memset` activities, we were missing the creation of  the `cpu_instant_event` `[memory]` events needed by the TensorBoard memory view. This meant we were only showing deallocations in the Memory View. This PR ensures we correctly record allocations as well.

Note: this PR depends on PR #102 of the internal libaiupti repository.