### PR TITLE
Add release_record schema/validator and trace_validator scaffolding

### DIFF
--- a/release_record.template.json
+++ b/release_record.template.json
@@ -1,0 +1,17 @@
+{
+  "release": "torch-2.12.0+aiu.kineto.1.2.0",
+  "target_pytorch": "2.12.0",
+  "pinned_kineto_commit": "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678",
+  "previous_last_sync_commit": "7a731b6ae01cfc2b1fc75d83a91f84e682e43fd7",
+  "new_last_sync_commit": "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678",
+  "integrated_commits": [
+    "0123456789abcdef0123456789abcdef01234567",
+    "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678"
+  ],
+  "subcomponents": {
+    "libaiupti": "1.0.0",
+    "aiu_toolkit": "2.3.1",
+    "pytorch": "2.12.0",
+    "kineto_spyre": "1.2.0"
+  }
+}

--- a/scripts/test_validate_release_record.py
+++ b/scripts/test_validate_release_record.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Tests for the release_record.json schema-validation helper.
+
+Run from the repo root with::
+
+    python3 -m unittest scripts.test_validate_release_record
+
+or from this directory with::
+
+    python3 -m unittest test_validate_release_record
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+# Make the helper importable whether run as `scripts.test_...` or directly.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import validate_release_record as vrr  # noqa: E402
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TEMPLATE_PATH = os.path.join(REPO_ROOT, "release_record.template.json")
+
+# A 40-char SHA reused for pinned/new so the invariant holds.
+SHA_A = "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678"
+SHA_B = "0123456789abcdef0123456789abcdef01234567"
+
+VALID_RECORD = {
+    "release": "torch-2.12.0+aiu.kineto.1.2.0",
+    "target_pytorch": "2.12.0",
+    "pinned_kineto_commit": SHA_A,
+    "previous_last_sync_commit": "7a731b6ae01cfc2b1fc75d83a91f84e682e43fd7",
+    "new_last_sync_commit": SHA_A,
+    "integrated_commits": [SHA_B, SHA_A],
+    "subcomponents": {
+        "libaiupti": "1.0.0",
+        "aiu_toolkit": "2.3.1",
+        "pytorch": "2.12.0",
+        "kineto_spyre": "1.2.0",
+    },
+}
+
+
+def write_temp(record_obj) -> str:
+    """Write an object as JSON to a temp file and return its path."""
+    fd, path = tempfile.mkstemp(suffix=".json")
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        json.dump(record_obj, handle)
+    return path
+
+
+def write_temp_text(text: str) -> str:
+    fd, path = tempfile.mkstemp(suffix=".json")
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        handle.write(text)
+    return path
+
+
+class ValidateRecordTest(unittest.TestCase):
+    def test_valid_record_passes(self):
+        # Should not raise.
+        vrr.validate_record(copy.deepcopy(VALID_RECORD))
+
+    def test_missing_top_level_key_fails(self):
+        record = copy.deepcopy(VALID_RECORD)
+        del record["target_pytorch"]
+        with self.assertRaises(vrr.ReleaseRecordError) as ctx:
+            vrr.validate_record(record)
+        self.assertIn("target_pytorch", str(ctx.exception))
+
+    def test_subcomponent_empty_version_fails(self):
+        record = copy.deepcopy(VALID_RECORD)
+        record["subcomponents"]["libaiupti"] = "   "
+        with self.assertRaises(vrr.ReleaseRecordError) as ctx:
+            vrr.validate_record(record)
+        self.assertIn("libaiupti", str(ctx.exception))
+
+    def test_subcomponent_missing_fails(self):
+        record = copy.deepcopy(VALID_RECORD)
+        del record["subcomponents"]["kineto_spyre"]
+        with self.assertRaises(vrr.ReleaseRecordError) as ctx:
+            vrr.validate_record(record)
+        self.assertIn("kineto_spyre", str(ctx.exception))
+
+    def test_subcomponent_extra_fails(self):
+        record = copy.deepcopy(VALID_RECORD)
+        record["subcomponents"]["unexpected_dep"] = "9.9.9"
+        with self.assertRaises(vrr.ReleaseRecordError) as ctx:
+            vrr.validate_record(record)
+        self.assertIn("unexpected_dep", str(ctx.exception))
+
+    def test_subcomponent_non_string_version_fails(self):
+        record = copy.deepcopy(VALID_RECORD)
+        record["subcomponents"]["pytorch"] = ["2.12.0"]
+        with self.assertRaises(vrr.ReleaseRecordError) as ctx:
+            vrr.validate_record(record)
+        self.assertIn("pytorch", str(ctx.exception))
+
+    def test_sync_commit_mismatch_fails(self):
+        record = copy.deepcopy(VALID_RECORD)
+        record["new_last_sync_commit"] = SHA_B
+        with self.assertRaises(vrr.ReleaseRecordError) as ctx:
+            vrr.validate_record(record)
+        self.assertIn("new_last_sync_commit", str(ctx.exception))
+
+    def test_non_object_record_fails(self):
+        with self.assertRaises(vrr.ReleaseRecordError):
+            vrr.validate_record(["not", "an", "object"])
+
+
+class LoadRecordTest(unittest.TestCase):
+    def test_malformed_json_reported(self):
+        path = write_temp_text('{"release": "x",,}')
+        try:
+            with self.assertRaises(vrr.ReleaseRecordError) as ctx:
+                vrr.load_release_record(path)
+            self.assertIn("malformed JSON", str(ctx.exception))
+        finally:
+            os.remove(path)
+
+    def test_missing_file_reported(self):
+        with self.assertRaises(vrr.ReleaseRecordError) as ctx:
+            vrr.load_release_record("/nonexistent/release_record.json")
+        self.assertIn("not found", str(ctx.exception))
+
+    def test_load_then_validate_valid_temp_file(self):
+        path = write_temp(VALID_RECORD)
+        try:
+            vrr.validate_release_record(path)  # should not raise
+        finally:
+            os.remove(path)
+
+
+class TemplateTest(unittest.TestCase):
+    def test_template_is_valid(self):
+        # The shipped template must itself pass validation.
+        self.assertTrue(os.path.exists(TEMPLATE_PATH), TEMPLATE_PATH)
+        vrr.validate_release_record(TEMPLATE_PATH)
+
+
+class CliTest(unittest.TestCase):
+    def test_cli_passes_on_valid(self):
+        path = write_temp(VALID_RECORD)
+        try:
+            self.assertEqual(vrr.main(["validate_release_record.py", path]), 0)
+        finally:
+            os.remove(path)
+
+    def test_cli_fails_on_invalid(self):
+        record = copy.deepcopy(VALID_RECORD)
+        del record["release"]
+        path = write_temp(record)
+        try:
+            self.assertEqual(vrr.main(["validate_release_record.py", path]), 1)
+        finally:
+            os.remove(path)
+
+    def test_cli_usage_error(self):
+        self.assertEqual(vrr.main(["validate_release_record.py"]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate_release_record.py
+++ b/scripts/validate_release_record.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Validate a ``release_record.json`` provenance file.
+
+The release record is the single source of provenance truth for a
+kineto-spyre release (see the design's Data Models section). This helper loads
+a record and asserts the schema and invariants that the rest of the pipeline
+relies on:
+
+* all required top-level keys are present;
+* the ``subcomponents`` map contains exactly the four expected keys
+  (``libaiupti``, ``aiu_toolkit``, ``pytorch``, ``kineto_spyre``) and each maps
+  to exactly one non-empty version string (Requirement 9.1: every subcomponent
+  has exactly one recorded version identifier);
+* the invariant ``new_last_sync_commit == pinned_kineto_commit`` holds.
+
+Usage::
+
+    python validate_release_record.py <path/to/release_record.json>
+
+Exits ``0`` when the record is valid, non-zero with a clear message otherwise.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any, List
+
+# Top-level keys every release record must contain.
+REQUIRED_TOP_LEVEL_KEYS = (
+    "release",
+    "target_pytorch",
+    "pinned_kineto_commit",
+    "previous_last_sync_commit",
+    "new_last_sync_commit",
+    "integrated_commits",
+    "subcomponents",
+)
+
+# The subcomponents map must contain exactly these keys, no more, no fewer.
+EXPECTED_SUBCOMPONENTS = ("libaiupti", "aiu_toolkit", "pytorch", "kineto_spyre")
+
+
+class ReleaseRecordError(Exception):
+    """Raised when a release record is malformed or violates the schema."""
+
+
+def load_release_record(path: str) -> Any:
+    """Load and parse a release_record.json file.
+
+    Raises ``ReleaseRecordError`` with a clear message on a missing file or
+    malformed JSON.
+    """
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            text = handle.read()
+    except FileNotFoundError as exc:
+        raise ReleaseRecordError(f"release record not found: {path}") from exc
+    except OSError as exc:
+        raise ReleaseRecordError(f"could not read release record {path}: {exc}") from exc
+
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ReleaseRecordError(
+            f"malformed JSON in {path}: {exc.msg} (line {exc.lineno}, column {exc.colno})"
+        ) from exc
+
+
+def validate_record(record: Any) -> None:
+    """Validate a parsed release record against the schema and invariants.
+
+    Raises ``ReleaseRecordError`` describing the first violation found.
+    """
+    if not isinstance(record, dict):
+        raise ReleaseRecordError(
+            f"release record must be a JSON object, got {type(record).__name__}"
+        )
+
+    # 1. All required top-level keys present.
+    missing = [key for key in REQUIRED_TOP_LEVEL_KEYS if key not in record]
+    if missing:
+        raise ReleaseRecordError(
+            "missing required top-level key(s): " + ", ".join(sorted(missing))
+        )
+
+    # 2. subcomponents map: exactly the four expected keys, each a non-empty version string.
+    subcomponents = record["subcomponents"]
+    if not isinstance(subcomponents, dict):
+        raise ReleaseRecordError(
+            "'subcomponents' must be a JSON object mapping subcomponent -> version"
+        )
+
+    actual_keys = set(subcomponents)
+    expected_keys = set(EXPECTED_SUBCOMPONENTS)
+    missing_subs = expected_keys - actual_keys
+    extra_subs = actual_keys - expected_keys
+    if missing_subs:
+        raise ReleaseRecordError(
+            "missing subcomponent(s): " + ", ".join(sorted(missing_subs))
+        )
+    if extra_subs:
+        raise ReleaseRecordError(
+            "unexpected subcomponent(s): " + ", ".join(sorted(extra_subs))
+        )
+
+    # Each subcomponent maps to exactly one non-empty version string (Req 9.1).
+    for name in EXPECTED_SUBCOMPONENTS:
+        version = subcomponents[name]
+        if not isinstance(version, str):
+            raise ReleaseRecordError(
+                f"subcomponent '{name}' version must be a single string, "
+                f"got {type(version).__name__}"
+            )
+        if version.strip() == "":
+            raise ReleaseRecordError(
+                f"subcomponent '{name}' has an empty version identifier; "
+                "exactly one non-empty version is required (Req 9.1)"
+            )
+
+    # 3. Invariant: new_last_sync_commit == pinned_kineto_commit.
+    pinned = record["pinned_kineto_commit"]
+    new_sync = record["new_last_sync_commit"]
+    if new_sync != pinned:
+        raise ReleaseRecordError(
+            "invariant violated: new_last_sync_commit "
+            f"({new_sync!r}) must equal pinned_kineto_commit ({pinned!r})"
+        )
+
+
+def validate_release_record(path: str) -> None:
+    """Load and validate a release record file. Raises on any problem."""
+    record = load_release_record(path)
+    validate_record(record)
+
+
+def main(argv: List[str]) -> int:
+    if len(argv) != 2:
+        prog = argv[0] if argv else "validate_release_record.py"
+        print(f"usage: {prog} <path/to/release_record.json>", file=sys.stderr)
+        return 2
+
+    path = argv[1]
+    try:
+        validate_release_record(path)
+    except ReleaseRecordError as exc:
+        print(f"ERROR: invalid release record: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"OK: {path} is a valid release record")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tools/trace_validator/__init__.py
+++ b/tools/trace_validator/__init__.py
@@ -1,0 +1,6 @@
+"""Trace validator package for the kineto-spyre 2.12 release pipeline.
+
+This package will hold the pure ``validate_trace`` implementation and its CLI
+wrapper (added by task 6). It is a proper Python package so the validator and
+its tests can be imported and run on any machine with no AIU hardware.
+"""


### PR DESCRIPTION
## Summary

First step of the kineto-spyre 2.12 release pipeline: the provenance record schema and the trace-validator package scaffolding.

- `release_record.template.json` — provenance record template: `release`, `target_pytorch`, `pinned_kineto_commit`, `previous_last_sync_commit`, `new_last_sync_commit`, `integrated_commits[]`, and a `subcomponents` version map (`libaiupti`, `aiu_toolkit`, `pytorch`, `kineto_spyre`).
- `scripts/validate_release_record.py` — schema/invariant validator with a CLI: asserts exactly one non-empty version per subcomponent and the invariant `new_last_sync_commit == pinned_kineto_commit`.
- `scripts/test_validate_release_record.py` — 15 unit tests (stdlib `unittest`).
- `tools/trace_validator/` — package scaffolding for the trace validator (added in a later PR).

Note: upstream kineto is unversioned, so the pin is recorded as a commit SHA (no `pinned_kineto_tag` field).

## Testing

```
python3 -m unittest test_validate_release_record   # 15 tests, OK
python3 scripts/validate_release_record.py release_record.template.json   # OK
```

## Blocked features

None.