### PR TITLE
kineto-spyre 2.12: upstream sync pipeline (pin resolver, cherry-pick sync, provenance) (PR 1)

### DIFF
--- a/release_record.template.json
+++ b/release_record.template.json
@@ -1,0 +1,17 @@
+{
+  "release": "torch-2.12.0+aiu.kineto.1.2.0",
+  "target_pytorch": "2.12.0",
+  "pinned_kineto_commit": "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678",
+  "previous_last_sync_commit": "7a731b6ae01cfc2b1fc75d83a91f84e682e43fd7",
+  "new_last_sync_commit": "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678",
+  "integrated_commits": [
+    "0123456789abcdef0123456789abcdef01234567",
+    "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678"
+  ],
+  "subcomponents": {
+    "libaiupti": "1.0.0",
+    "aiu_toolkit": "2.3.1",
+    "pytorch": "2.12.0",
+    "kineto_spyre": "1.2.0"
+  }
+}

--- a/scripts/check_lost_aiu_changes.sh
+++ b/scripts/check_lost_aiu_changes.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# check_lost_aiu_changes.sh — lost-AIU-change guard (design Component 3 /
+# Error Handling).
+#
+# Run after a cherry-pick conflict has been resolved. It compares the paths
+# the resolved cherry-pick commit (HEAD) actually changed against the paths the
+# integrated upstream commit touches. If the resolution removed or overwrote a
+# Kineto_Spyre AIU-specific path (e.g. under libkineto/src/plugin/aiupti/ or any
+# other AIU/libaiupti code) that the integrated upstream commit does NOT modify,
+# that AIU change was lost during conflict resolution: the guard reports the
+# affected paths and stops (non-zero exit) so the sync does not continue.
+#
+# Requirements: 6.3 (retain AIU-specific changes not modified by the upstream
+# commit), 6.4 (report a lost-change error naming the affected paths and do not
+# continue).
+#
+# Usage:
+#   check_lost_aiu_changes.sh <integrated-upstream-commit-sha> [repo-path]
+#
+# Environment:
+#   REPO       repo path (overridden by the positional repo argument)
+#   HEAD_REF   the resolved cherry-pick commit to inspect (default: HEAD)
+#   AIU_PATHS  whitespace-separated substrings identifying AIU-specific paths
+#              (default: "libkineto/src/plugin/aiupti aiupti libaiupti FindAIUToolkit")
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_REPO="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+UPSTREAM_SHA="${1:-}"
+REPO="${2:-${REPO:-$DEFAULT_REPO}}"
+HEAD_REF="${HEAD_REF:-HEAD}"
+AIU_PATHS="${AIU_PATHS:-libkineto/src/plugin/aiupti aiupti libaiupti FindAIUToolkit}"
+
+[ -n "$UPSTREAM_SHA" ] || die "usage: check_lost_aiu_changes.sh <integrated-upstream-commit-sha> [repo-path]"
+[ -d "$REPO" ] || die "repo path does not exist: $REPO"
+
+git -C "$REPO" cat-file -e "${UPSTREAM_SHA}^{commit}" 2>/dev/null \
+  || die "integrated upstream commit not found in repo: $UPSTREAM_SHA"
+
+# Paths the resolved cherry-pick (HEAD) changed, with status (M/D/A/R…).
+HEAD_CHANGED="$(git -C "$REPO" show --name-status --pretty=format: "$HEAD_REF" | sed '/^$/d')"
+
+# Paths the integrated upstream commit touches.
+UPSTREAM_CHANGED="$(git -C "$REPO" show --name-only --pretty=format: "$UPSTREAM_SHA" | sed '/^$/d')"
+
+is_aiu_path() {
+  local path="$1" pat
+  for pat in $AIU_PATHS; do
+    case "$path" in
+      *"$pat"*) return 0;;
+    esac
+  done
+  return 1
+}
+
+lost=()
+while IFS="$(printf '\t')" read -r status path rest; do
+  [ -n "$path" ] || continue
+  # Only AIU-specific paths are guarded (Req 6.3).
+  is_aiu_path "$path" || continue
+  # "Removed or overwritten" => deleted (D), modified (M), or renamed (R).
+  case "$status" in
+    D*|M*|R*) : ;;
+    *) continue;;
+  esac
+  # If the integrated upstream commit also touches this path, the change is a
+  # legitimate part of the integration — not a lost AIU change.
+  if printf '%s\n' "$UPSTREAM_CHANGED" | grep -Fxq "$path"; then
+    continue
+  fi
+  lost+=("$path")
+done <<EOF
+$HEAD_CHANGED
+EOF
+
+if [ "${#lost[@]}" -gt 0 ]; then
+  echo "ERROR: lost AIU-specific change(s) during conflict resolution of upstream commit ${UPSTREAM_SHA}." >&2
+  echo "       The following AIU path(s) were removed/overwritten but are NOT modified by that upstream commit:" >&2
+  for p in "${lost[@]}"; do
+    echo "         - $p" >&2
+  done
+  echo "       Restore these changes before continuing the sync (Req 6.4)." >&2
+  exit 1
+fi
+
+echo "OK: no AIU-specific changes were lost resolving upstream commit ${UPSTREAM_SHA}."

--- a/scripts/record_sync.sh
+++ b/scripts/record_sync.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+#
+# record_sync.sh — Release Record + Provenance (design Component 3)
+#
+# Writes/updates release_record.json with the integrated upstream commit IDs
+# and the new Last_Sync_Commit, and rewrites the README sync line to point at
+# the newly synced upstream commit while reflecting the PyTorch 2.12 target.
+# The produced record is then validated with scripts/validate_release_record.py.
+#
+# Requirements: 1.2 (record every integrated SHA), 1.3 (record newest as the new
+# Last_Sync_Commit), 1.5 (update the README sync line).
+#
+# Every input is parameterised (flags or environment) so the script can be
+# exercised against fixture repositories without touching live repos.
+#
+# Usage:
+#   record_sync.sh \
+#       --repo PATH \
+#       --last-sync <40-hex> \
+#       --pinned-kineto-commit <40-hex> \
+#       [--target-pytorch 2.12.0] \
+#       [--release "torch-2.12.0+aiu.kineto.1.2.0"] \
+#       --libaiupti-version X --aiu-toolkit-version X \
+#       [--pytorch-version 2.12.0] --kineto-spyre-version X
+#
+# Each flag also has an environment-variable equivalent (REPO, LAST_SYNC,
+# PINNED_KINETO_COMMIT, TARGET_PYTORCH, RELEASE, LIBAIUPTI_VERSION,
+# AIU_TOOLKIT_VERSION, PYTORCH_VERSION, KINETO_SPYRE_VERSION, RECORD, README,
+# VALIDATOR).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_REPO="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# ---- Defaults (overridable by env, then by flags) -------------------------
+REPO="${REPO:-$DEFAULT_REPO}"
+LAST_SYNC="${LAST_SYNC:-}"
+PINNED_KINETO_COMMIT="${PINNED_KINETO_COMMIT:-}"
+TARGET_PYTORCH="${TARGET_PYTORCH:-2.12.0}"
+LIBAIUPTI_VERSION="${LIBAIUPTI_VERSION:-}"
+AIU_TOOLKIT_VERSION="${AIU_TOOLKIT_VERSION:-}"
+PYTORCH_VERSION="${PYTORCH_VERSION:-}"
+KINETO_SPYRE_VERSION="${KINETO_SPYRE_VERSION:-}"
+RELEASE="${RELEASE:-}"
+RECORD="${RECORD:-}"
+README="${README:-}"
+VALIDATOR="${VALIDATOR:-${SCRIPT_DIR}/validate_release_record.py}"
+
+usage() {
+  sed -n '2,40p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+# ---- Flag parsing ----------------------------------------------------------
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --repo)                  REPO="$2"; shift 2;;
+    --last-sync)             LAST_SYNC="$2"; shift 2;;
+    --pinned-kineto-commit)  PINNED_KINETO_COMMIT="$2"; shift 2;;
+    --target-pytorch)        TARGET_PYTORCH="$2"; shift 2;;
+    --release)               RELEASE="$2"; shift 2;;
+    --libaiupti-version)     LIBAIUPTI_VERSION="$2"; shift 2;;
+    --aiu-toolkit-version)   AIU_TOOLKIT_VERSION="$2"; shift 2;;
+    --pytorch-version)       PYTORCH_VERSION="$2"; shift 2;;
+    --kineto-spyre-version)  KINETO_SPYRE_VERSION="$2"; shift 2;;
+    --record)                RECORD="$2"; shift 2;;
+    --readme)                README="$2"; shift 2;;
+    --validator)             VALIDATOR="$2"; shift 2;;
+    -h|--help)               usage; exit 0;;
+    *) die "unknown argument: $1";;
+  esac
+done
+
+# ---- Derive remaining defaults --------------------------------------------
+PYTORCH_VERSION="${PYTORCH_VERSION:-$TARGET_PYTORCH}"
+RECORD="${RECORD:-${REPO}/release_record.json}"
+README="${README:-${REPO}/README.md}"
+RELEASE="${RELEASE:-torch-${TARGET_PYTORCH}+aiu.kineto.${KINETO_SPYRE_VERSION}}"
+
+# ---- Validate inputs -------------------------------------------------------
+[ -d "$REPO" ] || die "repo path does not exist: $REPO"
+[ -n "$LAST_SYNC" ] || die "--last-sync (LAST_SYNC) is required"
+[ -n "$PINNED_KINETO_COMMIT" ] || die "--pinned-kineto-commit (PINNED_KINETO_COMMIT) is required"
+echo "$LAST_SYNC" | grep -Eq '^[0-9a-f]{40}$' || die "LAST_SYNC is not a 40-char SHA: $LAST_SYNC"
+echo "$PINNED_KINETO_COMMIT" | grep -Eq '^[0-9a-f]{40}$' || die "PINNED_KINETO_COMMIT is not a 40-char SHA: $PINNED_KINETO_COMMIT"
+[ -n "$LIBAIUPTI_VERSION" ]    || die "--libaiupti-version is required (Req 9.1)"
+[ -n "$AIU_TOOLKIT_VERSION" ]  || die "--aiu-toolkit-version is required (Req 9.1)"
+[ -n "$PYTORCH_VERSION" ]      || die "--pytorch-version is required (Req 9.1)"
+[ -n "$KINETO_SPYRE_VERSION" ] || die "--kineto-spyre-version is required (Req 9.1)"
+[ -f "$README" ] || die "README not found: $README"
+[ -f "$VALIDATOR" ] || die "validator not found: $VALIDATOR"
+
+# ---- 1. Extract integrated upstream SHAs in ascending order (Req 1.2) ------
+# Each cherry-picked commit carries an `-x` provenance line of the form
+# "(cherry picked from commit <40-hex>)". Reading them with --reverse yields
+# the integrated commits in ascending chronological order.
+INTEGRATED="$(
+  git -C "$REPO" log --reverse --pretty=%B "${LAST_SYNC}..HEAD" \
+    | grep -oE 'cherry picked from commit [0-9a-f]{40}' \
+    | awk '{print $5}' || true
+)"
+
+# ---- 2. Determine the new Last_Sync_Commit (Req 1.3) -----------------------
+# The newest integrated commit is the last one in ascending order. By the
+# cherry-pick range (… last inclusive) it must equal the pinned commit; the
+# schema validator enforces new_last_sync_commit == pinned_kineto_commit.
+if [ -n "$INTEGRATED" ]; then
+  NEW_LAST_SYNC="$(printf '%s\n' "$INTEGRATED" | tail -n 1)"
+else
+  NEW_LAST_SYNC="$PINNED_KINETO_COMMIT"
+fi
+
+if [ "$NEW_LAST_SYNC" != "$PINNED_KINETO_COMMIT" ]; then
+  echo "WARNING: newest integrated commit ($NEW_LAST_SYNC) != pinned commit ($PINNED_KINETO_COMMIT);" >&2
+  echo "         the release record will fail schema validation (invariant new==pinned)." >&2
+fi
+
+# ---- 3. Write release_record.json -----------------------------------------
+INTEGRATED_FILE="$(mktemp)"
+TMP_README="$(mktemp)"
+TMP_README2="$(mktemp)"
+cleanup() { rm -f "$INTEGRATED_FILE" "$TMP_README" "$TMP_README2"; }
+trap cleanup EXIT
+
+printf '%s' "$INTEGRATED" > "$INTEGRATED_FILE"
+
+export RELEASE TARGET_PYTORCH PINNED_KINETO_COMMIT LAST_SYNC NEW_LAST_SYNC \
+       LIBAIUPTI_VERSION AIU_TOOLKIT_VERSION PYTORCH_VERSION KINETO_SPYRE_VERSION
+
+python3 - "$RECORD" "$INTEGRATED_FILE" <<'PY'
+import json
+import os
+import sys
+
+record_path, integrated_file = sys.argv[1], sys.argv[2]
+
+with open(integrated_file, encoding="utf-8") as handle:
+    integrated = [line.strip() for line in handle if line.strip()]
+
+record = {
+    "release": os.environ["RELEASE"],
+    "target_pytorch": os.environ["TARGET_PYTORCH"],
+    "pinned_kineto_commit": os.environ["PINNED_KINETO_COMMIT"],
+    "previous_last_sync_commit": os.environ["LAST_SYNC"],
+    "new_last_sync_commit": os.environ["NEW_LAST_SYNC"],
+    "integrated_commits": integrated,
+    "subcomponents": {
+        "libaiupti": os.environ["LIBAIUPTI_VERSION"],
+        "aiu_toolkit": os.environ["AIU_TOOLKIT_VERSION"],
+        "pytorch": os.environ["PYTORCH_VERSION"],
+        "kineto_spyre": os.environ["KINETO_SPYRE_VERSION"],
+    },
+}
+
+with open(record_path, "w", encoding="utf-8") as handle:
+    json.dump(record, handle, indent=2)
+    handle.write("\n")
+PY
+
+echo "Wrote release record: $RECORD"
+echo "  integrated commits: $(printf '%s\n' "$INTEGRATED" | grep -c . || true)"
+echo "  new_last_sync_commit: $NEW_LAST_SYNC"
+
+# ---- 4. Rewrite the README sync line (Req 1.5) -----------------------------
+# Replace the 40-hex commit inside the backticked "last upstream sync" line.
+sed "s/The last upstream sync was with the commit \`[0-9a-f]\{40\}\`/The last upstream sync was with the commit \`${NEW_LAST_SYNC}\`/" \
+  "$README" > "$TMP_README"
+
+# Reflect the PyTorch 2.12 target on a dedicated, idempotent line placed right
+# after the sync line. Remove any prior target line first so re-runs do not
+# accumulate duplicates.
+TARGET_MM="$(printf '%s' "$TARGET_PYTORCH" | cut -d. -f1,2)"
+TARGET_LINE="This release targets PyTorch \`${TARGET_MM}\`."
+
+grep -v '^This release targets PyTorch ' "$TMP_README" > "$TMP_README2" || true
+
+awk -v line="$TARGET_LINE" '
+  { print }
+  /^The last upstream sync was with the commit/ && !done { print line; done = 1 }
+' "$TMP_README2" > "$README"
+
+echo "Updated README sync line and PyTorch target in: $README"
+
+# ---- 5. Validate the produced record --------------------------------------
+python3 "$VALIDATOR" "$RECORD"
+
+echo "record_sync.sh: done."

--- a/scripts/resolve_pin.sh
+++ b/scripts/resolve_pin.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+#
+# resolve_pin.sh — Pin Resolver (release pipeline Stage A / design Component 1)
+#
+# Determine Pinned_Kineto_Commit for the kineto-spyre 2.12 release and verify it
+# is a real, fetchable commit in upstream kineto.
+#
+#   * Read the `third_party/kineto` gitlink recorded at the PyTorch v2.12.0 tag
+#     (via `git ls-tree`) to determine PINNED_KINETO_COMMIT — the commit SHA.
+#     Upstream kineto is UNVERSIONED: PyTorch pins it to a plain main-branch
+#     commit, so the pin is the 40-char SHA itself, NOT a release tag. We never
+#     run `git describe --tags`.
+#   * Verify that commit exists locally, or can be fetched, as a real commit
+#     object in upstream kineto.
+#
+# Guards:
+#   Req 2.5 — stop (non-zero) when the v2.12.0 tag has no third_party/kineto ref.
+#   Req 2.6 — stop (non-zero) when the pinned commit cannot be found/fetched as a
+#             real commit in upstream kineto.
+#   Req 2.8 — the missing-reference stop is LOCAL: this script `exit`s its own
+#             process with a non-zero status. It never signals or terminates any
+#             sibling/parent process; other components may keep running.
+#
+# Output:
+#   * `PINNED_KINETO_COMMIT=<sha>` on stdout (the only machine-readable line).
+#   * If PIN_OUTPUT_FILE is set, the same `PINNED_KINETO_COMMIT=<sha>` line is
+#     also written to that file.
+#   * NO tag is emitted — the pin is the commit SHA only.
+#   * All diagnostics go to stderr, so stdout stays clean for callers.
+#
+# Configuration (parameters / env vars, so the script is testable on fixtures):
+#   PYTORCH_SRC          path to the PyTorch checkout (has the v2.12.0 tag).      [required]
+#   UPSTREAM_KINETO      path to an upstream-kineto checkout to verify against.   [required]
+#   PYTORCH_TAG          PyTorch tag to read the gitlink from. Default: v2.12.0.
+#   KINETO_SUBMODULE     submodule path inside PyTorch. Default: third_party/kineto.
+#   UPSTREAM_REMOTE_URL  URL/path used for the `upstream` remote when fetching.
+#                        Default: https://github.com/pytorch/kineto.git
+#   UPSTREAM_REMOTE_NAME name of the remote to (re)create. Default: upstream.
+#   PIN_OUTPUT_FILE      optional file to also write PINNED_KINETO_COMMIT= to.
+#
+# Usage:
+#   PYTORCH_SRC=/path/to/pytorch UPSTREAM_KINETO=/path/to/kineto ./scripts/resolve_pin.sh
+#
+set -euo pipefail
+
+# --- configuration -----------------------------------------------------------
+PYTORCH_SRC="${PYTORCH_SRC:-}"
+UPSTREAM_KINETO="${UPSTREAM_KINETO:-}"
+PYTORCH_TAG="${PYTORCH_TAG:-v2.12.0}"
+KINETO_SUBMODULE="${KINETO_SUBMODULE:-third_party/kineto}"
+UPSTREAM_REMOTE_URL="${UPSTREAM_REMOTE_URL:-https://github.com/pytorch/kineto.git}"
+UPSTREAM_REMOTE_NAME="${UPSTREAM_REMOTE_NAME:-upstream}"
+PIN_OUTPUT_FILE="${PIN_OUTPUT_FILE:-}"
+
+err() { echo "ERROR: $*" >&2; }
+info() { echo "$*" >&2; }
+
+# --- argument / environment validation ---------------------------------------
+if [ -z "$PYTORCH_SRC" ]; then
+  err "PYTORCH_SRC is not set (path to the PyTorch checkout with the ${PYTORCH_TAG} tag)"
+  exit 1
+fi
+if [ -z "$UPSTREAM_KINETO" ]; then
+  err "UPSTREAM_KINETO is not set (path to an upstream-kineto checkout)"
+  exit 1
+fi
+if [ ! -d "$PYTORCH_SRC" ]; then
+  err "PYTORCH_SRC '$PYTORCH_SRC' is not a directory"
+  exit 1
+fi
+if [ ! -d "$UPSTREAM_KINETO" ]; then
+  err "UPSTREAM_KINETO '$UPSTREAM_KINETO' is not a directory"
+  exit 1
+fi
+
+# --- 1. read the third_party/kineto gitlink at the PyTorch tag ----------------
+# The gitlink is stored in the tag's tree object, so `git ls-tree` against the
+# tag works even when the submodule is not checked out locally. We do NOT use
+# `git describe --tags` — upstream kineto is unversioned; the pin is the SHA.
+
+# Confirm the tag exists, with a clear message otherwise.
+if ! git -C "$PYTORCH_SRC" rev-parse -q --verify "refs/tags/${PYTORCH_TAG}" >/dev/null 2>&1; then
+  err "PyTorch checkout '$PYTORCH_SRC' has no tag '${PYTORCH_TAG}'"
+  exit 1
+fi
+
+# Read the tree entry for the submodule path. A gitlink prints as:
+#   160000 commit <sha>\t<path>
+# An absent path prints nothing (and exits 0).
+ls_tree_line="$(git -C "$PYTORCH_SRC" ls-tree "$PYTORCH_TAG" "$KINETO_SUBMODULE" || true)"
+
+# Guard (Req 2.5): the tag must actually reference a commit at the submodule path.
+if [ -z "$ls_tree_line" ]; then
+  err "PyTorch ${PYTORCH_TAG} has no '${KINETO_SUBMODULE}' reference"
+  # Req 2.8: stop ONLY this process (local non-zero exit); do not signal others.
+  exit 1
+fi
+
+entry_type="$(printf '%s\n' "$ls_tree_line" | awk '{print $2}')"
+PINNED_KINETO_COMMIT="$(printf '%s\n' "$ls_tree_line" | awk '{print $3}')"
+
+# The reference must be a gitlink (a `commit` entry), not a tree/blob, and must
+# be a real 40-char SHA. Otherwise the tag does not reference a kineto commit.
+if [ "$entry_type" != "commit" ] || ! printf '%s' "$PINNED_KINETO_COMMIT" | grep -Eq '^[0-9a-f]{40}$'; then
+  err "PyTorch ${PYTORCH_TAG} '${KINETO_SUBMODULE}' is not a commit reference (got: ${ls_tree_line})"
+  exit 1   # Req 2.5: no usable commit reference -> stop before integration
+fi
+
+info "Pinned_Kineto_Commit = ${PINNED_KINETO_COMMIT}"
+
+# --- 2. verify the commit is real / fetchable in upstream kineto --------------
+# Upstream kineto is unversioned, so there is no tag to resolve — we only
+# confirm the SHA exists and can be obtained as a commit object (Req 2.6).
+
+commit_exists() {
+  git -C "$UPSTREAM_KINETO" cat-file -e "${PINNED_KINETO_COMMIT}^{commit}" 2>/dev/null
+}
+
+if commit_exists; then
+  info "Pinned_Kineto_Commit already present in upstream kineto"
+else
+  # Not present locally — (re)point the upstream remote and try to fetch exactly
+  # that commit. Recreating the remote ensures we use the configured URL/path.
+  info "Pinned_Kineto_Commit not local; attempting to fetch from '${UPSTREAM_REMOTE_NAME}' (${UPSTREAM_REMOTE_URL})"
+  git -C "$UPSTREAM_KINETO" remote remove "$UPSTREAM_REMOTE_NAME" >/dev/null 2>&1 || true
+  git -C "$UPSTREAM_KINETO" remote add "$UPSTREAM_REMOTE_NAME" "$UPSTREAM_REMOTE_URL"
+
+  fetched=0
+  if git -C "$UPSTREAM_KINETO" fetch --quiet "$UPSTREAM_REMOTE_NAME" "$PINNED_KINETO_COMMIT" 2>/dev/null; then
+    fetched=1
+  fi
+
+  if [ "$fetched" -ne 1 ] || ! commit_exists; then
+    err "${PINNED_KINETO_COMMIT} cannot be found or fetched as a commit in upstream kineto"
+    exit 1   # Req 2.6: stop before integration
+  fi
+fi
+
+info "Pinned_Kineto_Commit resolved and fetchable in upstream kineto"
+
+# --- 3. emit the pin ----------------------------------------------------------
+# stdout: the single machine-readable line. No tag output (the pin is the SHA).
+echo "PINNED_KINETO_COMMIT=${PINNED_KINETO_COMMIT}"
+
+if [ -n "$PIN_OUTPUT_FILE" ]; then
+  echo "PINNED_KINETO_COMMIT=${PINNED_KINETO_COMMIT}" > "$PIN_OUTPUT_FILE"
+  info "Wrote pin to ${PIN_OUTPUT_FILE}"
+fi

--- a/scripts/sync_upstream.sh
+++ b/scripts/sync_upstream.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+#
+# sync_upstream.sh — Component 2: Upstream Sync
+#
+# Cherry-pick the upstream kineto commit range from *after* Last_Sync_Commit
+# (exclusive) through Pinned_Kineto_Commit (inclusive), applied in ascending
+# chronological order, preserving empty (no-op) commits as empty commits and
+# never integrating any commit newer than the pinned commit.
+#
+# On a cherry-pick conflict the script halts before any further pick, reports
+# the conflicting upstream commit ID and the conflicted paths on stderr,
+# retains every commit already integrated, and exits non-zero.
+#
+# Implements Requirements 1.1, 1.4, 1.7, 1.8, 2.4, 6.1, 6.2, 6.5.
+#
+# Parameters (positional args take precedence over environment):
+#   $1 / LAST_SYNC               last synced upstream commit (range start, EXCLUSIVE)
+#   $2 / PINNED_KINETO_COMMIT    pinned upstream commit (range end, INCLUSIVE)
+#
+# Environment overrides (all optional, parameterized for testability):
+#   REPO_PATH        path to the kineto-spyre fork working tree (default: $PWD)
+#   UPSTREAM_URL     upstream kineto remote URL
+#                    (default: https://github.com/pytorch/kineto.git)
+#   UPSTREAM_REMOTE  name of the upstream remote (default: upstream)
+#
+# Exit codes:
+#   0  all commits in the range integrated successfully
+#   2  cherry-pick halted on a merge conflict (tree left conflicted)
+#   1  usage / pre-flight error (bad args, unknown commit, etc.)
+
+set -euo pipefail
+
+# --------------------------------------------------------------------------
+# Parameters
+# --------------------------------------------------------------------------
+REPO_PATH="${REPO_PATH:-$PWD}"
+LAST_SYNC="${1:-${LAST_SYNC:-}}"
+PINNED_KINETO_COMMIT="${2:-${PINNED_KINETO_COMMIT:-}}"
+UPSTREAM_URL="${UPSTREAM_URL:-https://github.com/pytorch/kineto.git}"
+UPSTREAM_REMOTE="${UPSTREAM_REMOTE:-upstream}"
+
+if [ -z "$LAST_SYNC" ] || [ -z "$PINNED_KINETO_COMMIT" ]; then
+  echo "usage: sync_upstream.sh <LAST_SYNC> <PINNED_KINETO_COMMIT>" >&2
+  echo "       (or set LAST_SYNC / PINNED_KINETO_COMMIT in the environment)" >&2
+  exit 1
+fi
+
+# Run every git invocation against the target repository.
+git_repo() { git -C "$REPO_PATH" "$@"; }
+
+if ! git_repo rev-parse --git-dir >/dev/null 2>&1; then
+  echo "ERROR: $REPO_PATH is not a git repository" >&2
+  exit 1
+fi
+
+# --------------------------------------------------------------------------
+# 1. Add the upstream kineto remote (idempotent) and fetch tags + history.
+#    The URL is overridable so tests can point at a local fixture repo.
+# --------------------------------------------------------------------------
+if git_repo remote get-url "$UPSTREAM_REMOTE" >/dev/null 2>&1; then
+  git_repo remote set-url "$UPSTREAM_REMOTE" "$UPSTREAM_URL"
+else
+  git_repo remote add "$UPSTREAM_REMOTE" "$UPSTREAM_URL"
+fi
+git_repo fetch "$UPSTREAM_REMOTE" --tags
+
+# --------------------------------------------------------------------------
+# Pre-flight: both range endpoints must resolve to real commits.
+# --------------------------------------------------------------------------
+for ref in "$LAST_SYNC" "$PINNED_KINETO_COMMIT"; do
+  if ! git_repo cat-file -e "${ref}^{commit}" 2>/dev/null; then
+    echo "ERROR: $ref cannot be resolved to a commit in $REPO_PATH" >&2
+    exit 1
+  fi
+done
+
+# --------------------------------------------------------------------------
+# 2. Compute the cherry-pick range. "A..B" is EXCLUSIVE of A and INCLUSIVE of
+#    B — exactly the "first exclusive, last inclusive" rule (Req 1.1). Because
+#    the range stops at PINNED_KINETO_COMMIT, no commit newer than the pinned
+#    commit is ever considered (Req 2.4). --reverse lists ascending so we can
+#    report the integration order; cherry-pick of the range applies oldest
+#    first regardless.
+# --------------------------------------------------------------------------
+RANGE="${LAST_SYNC}..${PINNED_KINETO_COMMIT}"
+COMMIT_COUNT="$(git_repo rev-list --count "$RANGE")"
+echo "Will integrate ${COMMIT_COUNT} commit(s) over range ${RANGE} (ascending)"
+
+if [ "$COMMIT_COUNT" -eq 0 ]; then
+  echo "Nothing to integrate: range ${RANGE} is empty."
+  exit 0
+fi
+
+# --------------------------------------------------------------------------
+# 3. Cherry-pick the whole range.
+#    -x            records the source SHA in each message for provenance.
+#    --empty=keep  preserves a no-op commit as an EMPTY commit instead of
+#                  dropping it (Req 1.4). Change-producing commits take the
+#                  default path and remain regular non-empty commits (Req 1.7).
+#    A range cherry-pick applies oldest -> newest (ascending, Req 1.1) and
+#    will NOT advance past a conflicted commit (Req 6.2).
+# --------------------------------------------------------------------------
+if git_repo cherry-pick -x --empty=keep "$RANGE"; then
+  echo "Integrated ${COMMIT_COUNT} commit(s) up to and including ${PINNED_KINETO_COMMIT}"
+  exit 0
+fi
+
+# --------------------------------------------------------------------------
+# Conflict handling (Req 6.1, 6.2, 1.8).
+#
+# Conflict reporting takes PRIORITY over retention bookkeeping: capture and
+# emit the conflicting upstream commit ID FIRST and independently, so that a
+# retention failure can never suppress the conflict report (Req 1.8).
+# --------------------------------------------------------------------------
+CONFLICT_SHA=""
+if CONFLICT_SHA="$(git_repo rev-parse --verify --quiet CHERRY_PICK_HEAD)"; then
+  echo "CONFLICT while integrating upstream commit ${CONFLICT_SHA}" >&2
+else
+  # Not in a cherry-pick conflict state: the failure was something else.
+  echo "ERROR: cherry-pick of range ${RANGE} failed without a conflict to report" >&2
+  exit 1
+fi
+
+# Now (and only now) the secondary retention/path bookkeeping. Even if this
+# section were to misbehave, the conflicting commit ID above is already on
+# stderr (Req 1.8).
+echo "Conflicted paths:" >&2
+git_repo diff --name-only --diff-filter=U >&2 || true
+
+# Req 6.1/6.2: every commit already integrated is retained (they are committed
+# to the branch) and no further commit is picked while the tree is conflicted.
+echo "Halting: resolve the conflict and run 'git cherry-pick --continue' to" >&2
+echo "         resume integration in the original upstream commit order." >&2
+exit 2

--- a/scripts/test_record_sync.py
+++ b/scripts/test_record_sync.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Tests for the sync provenance scripts (design Component 3).
+
+These drive the bash scripts (``record_sync.sh`` and
+``check_lost_aiu_changes.sh``) via ``subprocess`` against throwaway fixture git
+repositories created in temp dirs. Nothing here touches a live repo.
+
+Run from the repo root with::
+
+    python3 -m unittest scripts.test_record_sync
+
+or from this directory with::
+
+    python3 -m unittest test_record_sync
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+RECORD_SYNC = os.path.join(SCRIPT_DIR, "record_sync.sh")
+GUARD = os.path.join(SCRIPT_DIR, "check_lost_aiu_changes.sh")
+VALIDATOR = os.path.join(SCRIPT_DIR, "validate_release_record.py")
+
+# Fabricated 40-hex upstream SHAs (ascending), newest == pinned commit.
+UPSTREAM_SHAS = [
+    "1111111111111111111111111111111111111111",
+    "2222222222222222222222222222222222222222",
+    "b2103f78d13fde4937af010c0ef8e24313568bc5",  # PyTorch v2.12.0 pin (newest)
+]
+
+README_SYNC_LINE = (
+    "The last upstream sync was with the commit "
+    "`7a731b6ae01cfc2b1fc75d83a91f84e682e43fd7`."
+)
+
+
+def run(cmd, cwd=None, env=None):
+    """Run a command, returning the CompletedProcess (captured output)."""
+    full_env = dict(os.environ)
+    if env:
+        full_env.update(env)
+    return subprocess.run(
+        cmd,
+        cwd=cwd,
+        env=full_env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def git(repo, *args):
+    """Run a git command in *repo*, raising on failure."""
+    proc = run(["git", "-C", repo, *args])
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"git {' '.join(args)} failed: {proc.stderr.strip() or proc.stdout.strip()}"
+        )
+    return proc.stdout.strip()
+
+
+def init_repo(path):
+    """Initialise a git repo with deterministic identity/branch."""
+    git(path, "init", "-q")
+    git(path, "config", "user.email", "test@example.com")
+    git(path, "config", "user.name", "Test User")
+    git(path, "config", "commit.gpgsign", "false")
+
+
+def write(path, content):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(content)
+
+
+class RecordSyncTest(unittest.TestCase):
+    def setUp(self):
+        self.repo = tempfile.mkdtemp(prefix="record_sync_")
+        self.addCleanup(shutil.rmtree, self.repo, ignore_errors=True)
+        init_repo(self.repo)
+
+        # README carrying the existing sync line.
+        readme = os.path.join(self.repo, "README.md")
+        write(readme, f"# kineto-spyre\n\n{README_SYNC_LINE}\n\nMore text.\n")
+        git(self.repo, "add", "README.md")
+        git(self.repo, "commit", "-q", "-m", "initial: README with sync line")
+
+        # This base commit is the previous Last_Sync point for the range.
+        self.last_sync = git(self.repo, "rev-parse", "HEAD")
+
+        # Create one commit per upstream SHA, each carrying an `-x` provenance
+        # line, in ascending order.
+        for i, sha in enumerate(UPSTREAM_SHAS):
+            fname = os.path.join(self.repo, f"file_{i}.txt")
+            write(fname, f"content {i}\n")
+            git(self.repo, "add", f"file_{i}.txt")
+            msg = f"integrate change {i}\n\n(cherry picked from commit {sha})"
+            git(self.repo, "commit", "-q", "-m", msg)
+
+        self.pinned = UPSTREAM_SHAS[-1]
+
+    def _run_record_sync(self):
+        return run(
+            [
+                "bash",
+                RECORD_SYNC,
+                "--repo", self.repo,
+                "--last-sync", self.last_sync,
+                "--pinned-kineto-commit", self.pinned,
+                "--target-pytorch", "2.12.0",
+                "--libaiupti-version", "1.0.0",
+                "--aiu-toolkit-version", "2.3.1",
+                "--kineto-spyre-version", "1.2.0",
+            ]
+        )
+
+    def test_record_and_readme_and_schema(self):
+        proc = self._run_record_sync()
+        self.assertEqual(
+            proc.returncode, 0,
+            f"record_sync.sh failed:\nSTDOUT:{proc.stdout}\nSTDERR:{proc.stderr}",
+        )
+
+        record_path = os.path.join(self.repo, "release_record.json")
+        self.assertTrue(os.path.exists(record_path), "release_record.json not written")
+        with open(record_path, encoding="utf-8") as handle:
+            record = json.load(handle)
+
+        # Recorded SHAs match and are ascending (Req 1.2).
+        self.assertEqual(record["integrated_commits"], UPSTREAM_SHAS)
+        self.assertEqual(
+            record["integrated_commits"],
+            sorted(record["integrated_commits"], key=UPSTREAM_SHAS.index),
+        )
+        self.assertEqual(record["integrated_commits"], list(UPSTREAM_SHAS))
+
+        # new_last_sync_commit is the newest integrated commit == pinned (Req 1.3).
+        self.assertEqual(record["new_last_sync_commit"], UPSTREAM_SHAS[-1])
+        self.assertEqual(record["new_last_sync_commit"], self.pinned)
+        self.assertEqual(record["previous_last_sync_commit"], self.last_sync)
+        self.assertEqual(record["target_pytorch"], "2.12.0")
+
+        # README sync line rewritten to the new commit (Req 1.5).
+        with open(os.path.join(self.repo, "README.md"), encoding="utf-8") as handle:
+            readme = handle.read()
+        self.assertIn(
+            f"The last upstream sync was with the commit `{self.pinned}`.",
+            readme,
+        )
+        self.assertNotIn("7a731b6ae01cfc2b1fc75d83a91f84e682e43fd7", readme)
+        # PyTorch 2.12 target reflected in the README.
+        self.assertIn("This release targets PyTorch `2.12`.", readme)
+
+        # Produced record passes the schema validator (exactly one non-empty
+        # version per subcomponent, invariant new == pinned).
+        vproc = run(["python3", VALIDATOR, record_path])
+        self.assertEqual(
+            vproc.returncode, 0,
+            f"validator rejected record:\n{vproc.stdout}\n{vproc.stderr}",
+        )
+
+    def test_idempotent_readme_no_duplicate_target_line(self):
+        self.assertEqual(self._run_record_sync().returncode, 0)
+        self.assertEqual(self._run_record_sync().returncode, 0)
+        with open(os.path.join(self.repo, "README.md"), encoding="utf-8") as handle:
+            readme = handle.read()
+        self.assertEqual(readme.count("This release targets PyTorch `2.12`."), 1)
+
+    def test_missing_required_subcomponent_version_fails(self):
+        proc = run(
+            [
+                "bash", RECORD_SYNC,
+                "--repo", self.repo,
+                "--last-sync", self.last_sync,
+                "--pinned-kineto-commit", self.pinned,
+                # libaiupti-version intentionally omitted
+                "--aiu-toolkit-version", "2.3.1",
+                "--kineto-spyre-version", "1.2.0",
+            ]
+        )
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("libaiupti", proc.stderr)
+
+
+class LostAiuGuardTest(unittest.TestCase):
+    AIU_FILE = "libkineto/src/plugin/aiupti/AiuptiActivityApi.cpp"
+    NORMAL_FILE = "libkineto/src/CuptiActivityApi.cpp"
+
+    def setUp(self):
+        self.repo = tempfile.mkdtemp(prefix="lost_aiu_")
+        self.addCleanup(shutil.rmtree, self.repo, ignore_errors=True)
+        init_repo(self.repo)
+
+        # Base: AIU plugin file + a normal file both present.
+        write(os.path.join(self.repo, self.AIU_FILE), "// AIU original\n")
+        write(os.path.join(self.repo, self.NORMAL_FILE), "// normal v1\n")
+        git(self.repo, "add", "-A")
+        git(self.repo, "commit", "-q", "-m", "base: AIU plugin + normal file")
+
+        # An "upstream" commit that modifies ONLY the normal file (it does not
+        # touch any AIU path).
+        write(os.path.join(self.repo, self.NORMAL_FILE), "// normal v2 from upstream\n")
+        git(self.repo, "add", "-A")
+        git(self.repo, "commit", "-q", "-m", "upstream: touch only the normal file")
+        self.upstream_sha = git(self.repo, "rev-parse", "HEAD")
+
+    def test_guard_flags_lost_aiu_change(self):
+        # Simulate a bad conflict resolution: HEAD overwrites the AIU file even
+        # though the upstream commit never touched it.
+        write(os.path.join(self.repo, self.AIU_FILE), "// AIU CLOBBERED\n")
+        write(os.path.join(self.repo, self.NORMAL_FILE), "// normal v2 from upstream\n")
+        git(self.repo, "add", "-A")
+        git(self.repo, "commit", "-q", "-m", "bad resolution: clobbered AIU file")
+
+        proc = run(["bash", GUARD, self.upstream_sha, self.repo])
+        self.assertNotEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        self.assertIn(self.AIU_FILE, proc.stderr)
+        self.assertIn("lost AIU-specific change", proc.stderr)
+
+    def test_guard_passes_when_aiu_preserved(self):
+        # A good resolution: HEAD only mirrors the upstream change to the normal
+        # file; the AIU file is untouched.
+        write(os.path.join(self.repo, self.NORMAL_FILE), "// normal v3 local resolution\n")
+        git(self.repo, "add", "-A")
+        git(self.repo, "commit", "-q", "-m", "good resolution: only normal file")
+
+        proc = run(["bash", GUARD, self.upstream_sha, self.repo])
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        self.assertIn("no AIU-specific changes were lost", proc.stdout)
+
+    def test_guard_ignores_aiu_change_that_upstream_also_makes(self):
+        # If the upstream commit itself modifies the AIU file, a matching HEAD
+        # change is a legitimate integration, not a lost change.
+        upstream_aiu = git  # alias for readability
+        # New upstream commit that DOES touch the AIU file.
+        write(os.path.join(self.repo, self.AIU_FILE), "// AIU changed upstream\n")
+        upstream_aiu(self.repo, "add", "-A")
+        upstream_aiu(self.repo, "commit", "-q", "-m", "upstream: modify AIU file")
+        upstream2 = git(self.repo, "rev-parse", "HEAD")
+
+        # HEAD applies the same AIU modification.
+        write(os.path.join(self.repo, self.AIU_FILE), "// AIU changed (integrated)\n")
+        git(self.repo, "add", "-A")
+        git(self.repo, "commit", "-q", "-m", "integrate AIU change")
+
+        proc = run(["bash", GUARD, upstream2, self.repo])
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_resolve_pin.py
+++ b/scripts/test_resolve_pin.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Tests for ``scripts/resolve_pin.sh`` (Pin Resolver, design Component 1).
+
+These drive the real bash script via ``subprocess`` against small fixture git
+repositories built in temp dirs. They cover:
+
+* Task 2.2 (integration, Req 2.1, 2.2): a fixture PyTorch repo whose
+  ``third_party/kineto`` gitlink points at a known SHA, plus a fixture upstream
+  kineto repo that actually contains that commit -> the script resolves the
+  expected SHA and verifies it is fetchable.
+* Task 2.3 (guards, Req 2.5, 2.6, 2.8): a fixture where the ``v2.12.0`` tag has
+  no ``third_party/kineto`` reference -> stop, non-zero; a fixture whose gitlink
+  points at a SHA absent from upstream kineto -> stop, non-zero (unfetchable);
+  and assertions that the stop is a *local* non-zero process exit that does not
+  terminate the test runner / parent (Req 2.8).
+
+Run from the repo root with::
+
+    python3 -m unittest scripts.test_resolve_pin
+
+or from this directory with::
+
+    python3 -m unittest test_resolve_pin
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+SCRIPT_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "resolve_pin.sh")
+
+# A syntactically valid 40-char SHA that will not exist in any fixture repo.
+ABSENT_SHA = "deadbeef" * 5  # 40 hex chars
+
+# Deterministic identity + isolation for fixture git operations.
+GIT_ENV = {
+    "GIT_AUTHOR_NAME": "Test",
+    "GIT_AUTHOR_EMAIL": "test@example.com",
+    "GIT_COMMITTER_NAME": "Test",
+    "GIT_COMMITTER_EMAIL": "test@example.com",
+    # Keep fixtures hermetic: ignore any global/system git config.
+    "GIT_CONFIG_NOSYSTEM": "1",
+    "HOME": tempfile.gettempdir(),
+}
+
+
+def git(repo: str, *args: str, check: bool = True) -> subprocess.CompletedProcess:
+    """Run a git command inside ``repo``."""
+    env = os.environ.copy()
+    env.update(GIT_ENV)
+    return subprocess.run(
+        ["git", "-C", repo, *args],
+        check=check,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def init_repo(path: str) -> None:
+    os.makedirs(path, exist_ok=True)
+    git(path, "init", "-q", "-b", "main")
+    git(path, "config", "user.email", "test@example.com")
+    git(path, "config", "user.name", "Test")
+
+
+def commit_file(repo: str, name: str, content: str, message: str) -> str:
+    """Create/overwrite a file, commit it, and return the new commit SHA."""
+    with open(os.path.join(repo, name), "w", encoding="utf-8") as handle:
+        handle.write(content)
+    git(repo, "add", name)
+    git(repo, "commit", "-q", "-m", message)
+    return git(repo, "rev-parse", "HEAD").stdout.strip()
+
+
+def add_gitlink(repo: str, submodule_path: str, sha: str) -> None:
+    """Add a gitlink (submodule pointer) at ``submodule_path`` -> ``sha``."""
+    git(repo, "update-index", "--add", "--cacheinfo", f"160000,{sha},{submodule_path}")
+
+
+def run_resolve_pin(pytorch_src: str, upstream_kineto: str, **extra_env):
+    """Invoke resolve_pin.sh and return the CompletedProcess."""
+    env = os.environ.copy()
+    env.update(GIT_ENV)
+    env["PYTORCH_SRC"] = pytorch_src
+    env["UPSTREAM_KINETO"] = upstream_kineto
+    env.update({k: str(v) for k, v in extra_env.items()})
+    return subprocess.run(
+        ["bash", SCRIPT_PATH],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+class ResolvePinTestBase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.mkdtemp(prefix="resolve_pin_test_")
+        self.pytorch = os.path.join(self.tmp, "pytorch")
+        self.upstream = os.path.join(self.tmp, "kineto")
+        init_repo(self.pytorch)
+        init_repo(self.upstream)
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def seed_upstream_with_commits(self) -> str:
+        """Seed the upstream fixture with a few commits; return the last SHA."""
+        commit_file(self.upstream, "a.txt", "1", "first upstream commit")
+        commit_file(self.upstream, "b.txt", "2", "second upstream commit")
+        return commit_file(self.upstream, "c.txt", "3", "pinned upstream commit")
+
+    def make_pytorch_tag_with_gitlink(self, sha: str, tag: str = "v2.12.0") -> None:
+        """Create a PyTorch fixture whose tag pins third_party/kineto -> sha."""
+        commit_file(self.pytorch, "version.txt", "2.12.0\n", "pytorch base")
+        add_gitlink(self.pytorch, "third_party/kineto", sha)
+        git(self.pytorch, "commit", "-q", "-m", "pin kineto submodule")
+        git(self.pytorch, "tag", tag)
+
+
+class IntegrationTest(ResolvePinTestBase):
+    """Task 2.2 — Req 2.1, 2.2."""
+
+    def test_resolves_expected_sha_and_verifies_fetchable(self):
+        pinned = self.seed_upstream_with_commits()
+        self.make_pytorch_tag_with_gitlink(pinned)
+
+        result = run_resolve_pin(self.pytorch, self.upstream)
+
+        self.assertEqual(
+            result.returncode, 0,
+            msg=f"expected success.\nstdout={result.stdout}\nstderr={result.stderr}",
+        )
+        # stdout carries exactly the machine-readable pin line, no tag output.
+        self.assertIn(f"PINNED_KINETO_COMMIT={pinned}", result.stdout)
+        self.assertNotIn("TAG", result.stdout.upper())
+        # The commit is present locally in upstream, so it is verified fetchable.
+        self.assertIn("resolved and fetchable", result.stderr)
+
+    def test_writes_pin_to_output_file(self):
+        pinned = self.seed_upstream_with_commits()
+        self.make_pytorch_tag_with_gitlink(pinned)
+        out_file = os.path.join(self.tmp, "pin.txt")
+
+        result = run_resolve_pin(self.pytorch, self.upstream, PIN_OUTPUT_FILE=out_file)
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        with open(out_file, encoding="utf-8") as handle:
+            self.assertEqual(handle.read().strip(), f"PINNED_KINETO_COMMIT={pinned}")
+
+
+class GuardTest(ResolvePinTestBase):
+    """Task 2.3 — Req 2.5, 2.6, 2.8."""
+
+    def test_missing_kineto_reference_stops_nonzero(self):
+        # Req 2.5: tag exists but has no third_party/kineto reference.
+        commit_file(self.pytorch, "version.txt", "2.12.0\n", "pytorch base")
+        git(self.pytorch, "tag", "v2.12.0")
+
+        result = run_resolve_pin(self.pytorch, self.upstream)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("no 'third_party/kineto' reference", result.stderr)
+        # No pin emitted on stdout when stopping before integration.
+        self.assertNotIn("PINNED_KINETO_COMMIT=", result.stdout)
+
+    def test_missing_reference_stop_is_local_not_a_signal(self):
+        # Req 2.8: the stop is a LOCAL non-zero process exit (via `exit`), not a
+        # signal that would terminate the parent/test runner. A subprocess killed
+        # by a signal reports a negative returncode in Python; a normal local
+        # exit reports a positive status. The test runner itself keeps going
+        # (this assertion executing at all proves the parent was not terminated).
+        commit_file(self.pytorch, "version.txt", "2.12.0\n", "pytorch base")
+        git(self.pytorch, "tag", "v2.12.0")
+
+        result = run_resolve_pin(self.pytorch, self.upstream)
+
+        self.assertGreater(
+            result.returncode, 0,
+            msg="missing-reference stop must be a local non-zero exit, not a signal",
+        )
+
+    def test_pinned_commit_absent_from_upstream_stops_nonzero(self):
+        # Req 2.6: gitlink points at a SHA that upstream kineto does not contain
+        # and cannot fetch. Point the upstream remote at a local repo (the
+        # upstream fixture itself) so no network access is attempted; that repo
+        # does not contain ABSENT_SHA, so the fetch fails cleanly.
+        self.seed_upstream_with_commits()
+        self.make_pytorch_tag_with_gitlink(ABSENT_SHA)
+
+        result = run_resolve_pin(
+            self.pytorch,
+            self.upstream,
+            UPSTREAM_REMOTE_URL=self.upstream,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertGreater(result.returncode, 0, msg="must be a local non-zero exit")
+        self.assertIn("cannot be found or fetched", result.stderr)
+        self.assertNotIn("PINNED_KINETO_COMMIT=", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_sync_upstream.py
+++ b/scripts/test_sync_upstream.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Tests for ``scripts/sync_upstream.sh`` (Component 2: Upstream Sync).
+
+These tests drive the real bash script via ``subprocess`` against throwaway
+fixture git repositories built with ``git init`` and real commits. No network
+access and no live repositories are touched — the upstream remote URL is
+overridden to point at a local fixture repo.
+
+Run from the repo root with::
+
+    python3 -m unittest scripts.test_sync_upstream
+
+or from this directory with::
+
+    python3 -m unittest test_sync_upstream
+
+Covers task 3.3 (integration: integrated set/order, conflict halt + reporting,
+ordered continuation) and task 3.4 (edge cases: empty-commit preservation,
+exclusive/inclusive range boundary, no commit newer than the pinned commit).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+SCRIPT_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "sync_upstream.sh")
+
+# Deterministic identity + environment so commits are reproducible and no
+# interactive editor / signing ever blocks a cherry-pick.
+GIT_ENV = {
+    "GIT_AUTHOR_NAME": "Test",
+    "GIT_AUTHOR_EMAIL": "test@example.com",
+    "GIT_COMMITTER_NAME": "Test",
+    "GIT_COMMITTER_EMAIL": "test@example.com",
+    "GIT_AUTHOR_DATE": "2020-01-01T00:00:00",
+    "GIT_COMMITTER_DATE": "2020-01-01T00:00:00",
+    "GIT_CONFIG_GLOBAL": "/dev/null",
+    "GIT_CONFIG_SYSTEM": "/dev/null",
+    "EDITOR": "true",
+    "GIT_EDITOR": "true",
+}
+
+
+def _full_env() -> dict:
+    env = os.environ.copy()
+    env.update(GIT_ENV)
+    return env
+
+
+def git(repo: str, *args: str) -> str:
+    """Run a git command in ``repo`` and return stripped stdout."""
+    result = subprocess.run(
+        ["git", "-C", repo, *args],
+        env=_full_env(),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+class GitFixture:
+    """A throwaway git repository with helpers to build a known history."""
+
+    def __init__(self, path: str):
+        self.path = path
+
+    @classmethod
+    def init(cls, path: str) -> "GitFixture":
+        os.makedirs(path, exist_ok=True)
+        subprocess.run(["git", "init", "-q", "-b", "main", path], env=_full_env(), check=True)
+        git(path, "config", "commit.gpgsign", "false")
+        git(path, "config", "user.name", "Test")
+        git(path, "config", "user.email", "test@example.com")
+        return cls(path)
+
+    def write(self, relpath: str, content: str) -> None:
+        full = os.path.join(self.path, relpath)
+        os.makedirs(os.path.dirname(full) or self.path, exist_ok=True)
+        with open(full, "w", encoding="utf-8") as handle:
+            handle.write(content)
+
+    def commit_file(self, relpath: str, content: str, message: str) -> str:
+        self.write(relpath, content)
+        git(self.path, "add", relpath)
+        git(self.path, "commit", "-q", "-m", message)
+        return self.head()
+
+    def commit_empty(self, message: str) -> str:
+        git(self.path, "commit", "-q", "--allow-empty", "-m", message)
+        return self.head()
+
+    def head(self) -> str:
+        return git(self.path, "rev-parse", "HEAD")
+
+
+def run_sync(fork: str, upstream: str, last_sync: str, pinned: str) -> subprocess.CompletedProcess:
+    """Invoke sync_upstream.sh against the fork, pointing upstream at a fixture."""
+    env = _full_env()
+    env.update(
+        {
+            "REPO_PATH": fork,
+            "UPSTREAM_URL": upstream,
+            "UPSTREAM_REMOTE": "upstream",
+        }
+    )
+    return subprocess.run(
+        ["bash", SCRIPT_PATH, last_sync, pinned],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def integrated_provenance_shas(fork: str, base: str) -> list:
+    """Return upstream SHAs recorded by ``-x`` in commits after ``base``, ascending."""
+    body = git(fork, "log", "--reverse", "--pretty=%B", f"{base}..HEAD")
+    return re.findall(r"cherry picked from commit ([0-9a-f]{40})", body)
+
+
+def is_empty_commit(fork: str, commit: str) -> bool:
+    """True when ``commit``'s tree equals its first parent's tree (a no-op)."""
+    tree = git(fork, "rev-parse", f"{commit}^{{tree}}")
+    parent_tree = git(fork, "rev-parse", f"{commit}^^{{tree}}")
+    return tree == parent_tree
+
+
+class SyncUpstreamTestBase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.mkdtemp(prefix="sync_upstream_test_")
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self.upstream_path = os.path.join(self.tmp, "upstream")
+        self.fork_path = os.path.join(self.tmp, "fork")
+
+
+class HappyPathTest(SyncUpstreamTestBase):
+    """Task 3.3/3.4: integrated set/order, empty preservation, range boundary."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        up = GitFixture.init(self.upstream_path)
+        # C0 = Last_Sync_Commit (range start, EXCLUSIVE).
+        self.c0 = up.commit_file("common.txt", "original\n", "C0 base (last sync)")
+        # C1 = change-producing (adds a file) -> must be a regular non-empty commit.
+        self.c1 = up.commit_file("feature1.txt", "f1\n", "C1 add feature1")
+        # C2 = no-op / empty commit -> must be preserved as an empty commit.
+        self.c2 = up.commit_empty("C2 empty no-op")
+        # C3 = PINNED (range end, INCLUSIVE), change-producing.
+        self.c3 = up.commit_file("feature2.txt", "f2\n", "C3 add feature2 (pinned)")
+        # C4 = beyond the pinned commit -> must NOT be integrated.
+        self.c4 = up.commit_file("feature3.txt", "f3\n", "C4 add feature3 (beyond pin)")
+
+        # Independent fork (no shared history) with an AIU-specific file.
+        fork = GitFixture.init(self.fork_path)
+        self.fork_base = fork.commit_file(
+            "aiu_plugin.txt", "aiu specific code\n", "fork base"
+        )
+
+    def test_integrates_expected_set_and_order(self):
+        proc = run_sync(self.fork_path, self.upstream_path, self.c0, self.c3)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+        shas = integrated_provenance_shas(self.fork_path, self.fork_base)
+        # Req 1.1: ascending order, C0 excluded, C3 included; C4 excluded (Req 2.4).
+        self.assertEqual(shas, [self.c1, self.c2, self.c3])
+
+    def test_range_boundary_excludes_last_sync_and_beyond_pinned(self):
+        proc = run_sync(self.fork_path, self.upstream_path, self.c0, self.c3)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+        shas = integrated_provenance_shas(self.fork_path, self.fork_base)
+        # Req 1.1 (exclusive start): C0 is never re-integrated.
+        self.assertNotIn(self.c0, shas)
+        # Req 2.4: nothing newer than the pinned commit is integrated.
+        self.assertNotIn(self.c4, shas)
+        # The beyond-pin file must be absent from the fork tree.
+        self.assertFalse(os.path.exists(os.path.join(self.fork_path, "feature3.txt")))
+        # The included files are present.
+        self.assertTrue(os.path.exists(os.path.join(self.fork_path, "feature1.txt")))
+        self.assertTrue(os.path.exists(os.path.join(self.fork_path, "feature2.txt")))
+
+    def test_change_producing_commit_is_regular_non_empty(self):
+        proc = run_sync(self.fork_path, self.upstream_path, self.c0, self.c3)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        # Req 1.7: the commit integrating C1 carries its file change (non-empty).
+        c1_commit = self._fork_commit_for(self.c1)
+        self.assertFalse(is_empty_commit(self.fork_path, c1_commit))
+
+    def test_empty_commit_preserved_not_skipped(self):
+        proc = run_sync(self.fork_path, self.upstream_path, self.c0, self.c3)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        # Req 1.4: the no-op commit C2 is kept as an EMPTY commit, never skipped.
+        shas = integrated_provenance_shas(self.fork_path, self.fork_base)
+        self.assertIn(self.c2, shas, "empty commit was dropped instead of preserved")
+        c2_commit = self._fork_commit_for(self.c2)
+        self.assertTrue(
+            is_empty_commit(self.fork_path, c2_commit),
+            "C2 should be preserved as an empty commit",
+        )
+
+    def _fork_commit_for(self, upstream_sha: str) -> str:
+        """Find the fork commit whose -x line references ``upstream_sha``."""
+        out = git(
+            self.fork_path,
+            "log",
+            "--pretty=%H%x1f%B%x1e",
+            f"{self.fork_base}..HEAD",
+        )
+        for record in out.split("\x1e"):
+            record = record.strip()
+            if not record:
+                continue
+            sha, _, body = record.partition("\x1f")
+            if upstream_sha in body:
+                return sha.strip()
+        self.fail(f"no fork commit references upstream {upstream_sha}")
+
+
+class ConflictTest(SyncUpstreamTestBase):
+    """Task 3.3: conflict halt + reporting, retention, ordered continuation."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        up = GitFixture.init(self.upstream_path)
+        # C0 = Last_Sync_Commit.
+        self.c0 = up.commit_file("common.txt", "original\n", "C0 base (last sync)")
+        # C1 = clean change (integrates before the conflict; must be retained).
+        self.c1 = up.commit_file("feature1.txt", "f1\n", "C1 add feature1")
+        # C2 = modifies common.txt -> conflicts with the fork-local change.
+        self.c2 = up.commit_file("common.txt", "upstream-modified\n", "C2 modify common")
+        # C3 = PINNED, clean change after the conflict (only after resolution).
+        self.c3 = up.commit_file("feature2.txt", "f2\n", "C3 add feature2 (pinned)")
+
+        fork = GitFixture.init(self.fork_path)
+        fork.commit_file("aiu_plugin.txt", "aiu specific code\n", "fork base")
+        # Fork-local divergent change to the same line C2 touches -> conflict.
+        self.fork_base = fork.commit_file(
+            "common.txt", "fork-modified\n", "fork local change to common"
+        )
+
+    def test_conflict_halts_reports_and_retains(self):
+        proc = run_sync(self.fork_path, self.upstream_path, self.c0, self.c3)
+
+        # Req 6.2: non-zero exit; the script halts on the conflict.
+        self.assertEqual(proc.returncode, 2, proc.stdout + proc.stderr)
+        # Req 6.1 / 1.8: the conflicting upstream SHA is reported on stderr.
+        self.assertIn(self.c2, proc.stderr)
+        # Req 6.1: the conflicted path is reported on stderr.
+        self.assertIn("common.txt", proc.stderr)
+        # The conflicting SHA is reported BEFORE the conflicted-paths bookkeeping
+        # (Req 1.8: conflict reporting takes priority over retention).
+        self.assertLess(
+            proc.stderr.index(self.c2),
+            proc.stderr.index("Conflicted paths"),
+        )
+
+        # Req 6.1: the already-integrated commit (C1) is retained.
+        shas = integrated_provenance_shas(self.fork_path, self.fork_base)
+        self.assertIn(self.c1, shas)
+        # Req 6.2: C3 (after the conflict) was NOT integrated while conflicted.
+        self.assertNotIn(self.c3, shas)
+        self.assertFalse(os.path.exists(os.path.join(self.fork_path, "feature2.txt")))
+        # The tree is still mid-cherry-pick (conflicted), not advanced.
+        self.assertTrue(
+            os.path.exists(os.path.join(self.fork_path, ".git", "CHERRY_PICK_HEAD"))
+        )
+
+    def test_continuation_after_resolution_proceeds_in_order(self):
+        proc = run_sync(self.fork_path, self.upstream_path, self.c0, self.c3)
+        self.assertEqual(proc.returncode, 2, proc.stdout + proc.stderr)
+
+        # Manually resolve the conflict, then continue — the script's documented
+        # recovery path (Req 6.5: continue in original upstream order).
+        with open(os.path.join(self.fork_path, "common.txt"), "w", encoding="utf-8") as fh:
+            fh.write("resolved\n")
+        git(self.fork_path, "add", "common.txt")
+        git(self.fork_path, "-c", "core.editor=true", "cherry-pick", "--continue")
+
+        shas = integrated_provenance_shas(self.fork_path, self.fork_base)
+        # Req 6.5: integration resumes in original upstream order C1 -> C2 -> C3.
+        self.assertEqual(shas, [self.c1, self.c2, self.c3])
+        self.assertTrue(os.path.exists(os.path.join(self.fork_path, "feature2.txt")))
+
+
+class UsageTest(SyncUpstreamTestBase):
+    def setUp(self) -> None:
+        super().setUp()
+        GitFixture.init(self.fork_path)
+
+    def test_missing_arguments_is_usage_error(self):
+        env = _full_env()
+        env["REPO_PATH"] = self.fork_path
+        proc = subprocess.run(
+            ["bash", SCRIPT_PATH],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("usage", proc.stderr.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_validate_release_record.py
+++ b/scripts/test_validate_release_record.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Tests for the release_record.json schema-validation helper.
+
+Run from the repo root with::
+
+    python3 -m unittest scripts.test_validate_release_record
+
+or from this directory with::
+
+    python3 -m unittest test_validate_release_record
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+# Make the helper importable whether run as `scripts.test_...` or directly.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import validate_release_record as vrr  # noqa: E402
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TEMPLATE_PATH = os.path.join(REPO_ROOT, "release_record.template.json")
+
+# A 40-char SHA reused for pinned/new so the invariant holds.
+SHA_A = "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678"
+SHA_B = "0123456789abcdef0123456789abcdef01234567"
+
+VALID_RECORD = {
+    "release": "torch-2.12.0+aiu.kineto.1.2.0",
+    "target_pytorch": "2.12.0",
+    "pinned_kineto_commit": SHA_A,
+    "previous_last_sync_commit": "7a731b6ae01cfc2b1fc75d83a91f84e682e43fd7",
+    "new_last_sync_commit": SHA_A,
+    "integrated_commits": [SHA_B, SHA_A],
+    "subcomponents": {
+        "libaiupti": "1.0.0",
+        "aiu_toolkit": "2.3.1",
+        "pytorch": "2.12.0",
+        "kineto_spyre": "1.2.0",
+    },
+}
+
+
+def write_temp(record_obj) -> str:
+    """Write an object as JSON to a temp file and return its path."""
+    fd, path = tempfile.mkstemp(suffix=".json")
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        json.dump(record_obj, handle)
+    return path
+
+
+def write_temp_text(text: str) -> str:
+    fd, path = tempfile.mkstemp(suffix=".json")
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        handle.write(text)
+    return path
+
+
+class ValidateRecordTest(unittest.TestCase):
+    def test_valid_record_passes(self):
+        # Should not raise.
+        vrr.validate_record(copy.deepcopy(VALID_RECORD))
+
+    def test_missing_top_level_key_fails(self):
+        record = copy.deepcopy(VALID_RECORD)
+        del record["target_pytorch"]
+        with self.assertRaises(vrr.ReleaseRecordError) as ctx:
+            vrr.validate_record(record)
+        self.assertIn("target_pytorch", str(ctx.exception))
+
+    def test_subcomponent_empty_version_fails(self):
+        record = copy.deepcopy(VALID_RECORD)
+        record["subcomponents"]["libaiupti"] = "   "
+        with self.assertRaises(vrr.ReleaseRecordError) as ctx:
+            vrr.validate_record(record)
+        self.assertIn("libaiupti", str(ctx.exception))
+
+    def test_subcomponent_missing_fails(self):
+        record = copy.deepcopy(VALID_RECORD)
+        del record["subcomponents"]["kineto_spyre"]
+        with self.assertRaises(vrr.ReleaseRecordError) as ctx:
+            vrr.validate_record(record)
+        self.assertIn("kineto_spyre", str(ctx.exception))
+
+    def test_subcomponent_extra_fails(self):
+        record = copy.deepcopy(VALID_RECORD)
+        record["subcomponents"]["unexpected_dep"] = "9.9.9"
+        with self.assertRaises(vrr.ReleaseRecordError) as ctx:
+            vrr.validate_record(record)
+        self.assertIn("unexpected_dep", str(ctx.exception))
+
+    def test_subcomponent_non_string_version_fails(self):
+        record = copy.deepcopy(VALID_RECORD)
+        record["subcomponents"]["pytorch"] = ["2.12.0"]
+        with self.assertRaises(vrr.ReleaseRecordError) as ctx:
+            vrr.validate_record(record)
+        self.assertIn("pytorch", str(ctx.exception))
+
+    def test_sync_commit_mismatch_fails(self):
+        record = copy.deepcopy(VALID_RECORD)
+        record["new_last_sync_commit"] = SHA_B
+        with self.assertRaises(vrr.ReleaseRecordError) as ctx:
+            vrr.validate_record(record)
+        self.assertIn("new_last_sync_commit", str(ctx.exception))
+
+    def test_non_object_record_fails(self):
+        with self.assertRaises(vrr.ReleaseRecordError):
+            vrr.validate_record(["not", "an", "object"])
+
+
+class LoadRecordTest(unittest.TestCase):
+    def test_malformed_json_reported(self):
+        path = write_temp_text('{"release": "x",,}')
+        try:
+            with self.assertRaises(vrr.ReleaseRecordError) as ctx:
+                vrr.load_release_record(path)
+            self.assertIn("malformed JSON", str(ctx.exception))
+        finally:
+            os.remove(path)
+
+    def test_missing_file_reported(self):
+        with self.assertRaises(vrr.ReleaseRecordError) as ctx:
+            vrr.load_release_record("/nonexistent/release_record.json")
+        self.assertIn("not found", str(ctx.exception))
+
+    def test_load_then_validate_valid_temp_file(self):
+        path = write_temp(VALID_RECORD)
+        try:
+            vrr.validate_release_record(path)  # should not raise
+        finally:
+            os.remove(path)
+
+
+class TemplateTest(unittest.TestCase):
+    def test_template_is_valid(self):
+        # The shipped template must itself pass validation.
+        self.assertTrue(os.path.exists(TEMPLATE_PATH), TEMPLATE_PATH)
+        vrr.validate_release_record(TEMPLATE_PATH)
+
+
+class CliTest(unittest.TestCase):
+    def test_cli_passes_on_valid(self):
+        path = write_temp(VALID_RECORD)
+        try:
+            self.assertEqual(vrr.main(["validate_release_record.py", path]), 0)
+        finally:
+            os.remove(path)
+
+    def test_cli_fails_on_invalid(self):
+        record = copy.deepcopy(VALID_RECORD)
+        del record["release"]
+        path = write_temp(record)
+        try:
+            self.assertEqual(vrr.main(["validate_release_record.py", path]), 1)
+        finally:
+            os.remove(path)
+
+    def test_cli_usage_error(self):
+        self.assertEqual(vrr.main(["validate_release_record.py"]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate_release_record.py
+++ b/scripts/validate_release_record.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Validate a ``release_record.json`` provenance file.
+
+The release record is the single source of provenance truth for a
+kineto-spyre release (see the design's Data Models section). This helper loads
+a record and asserts the schema and invariants that the rest of the pipeline
+relies on:
+
+* all required top-level keys are present;
+* the ``subcomponents`` map contains exactly the four expected keys
+  (``libaiupti``, ``aiu_toolkit``, ``pytorch``, ``kineto_spyre``) and each maps
+  to exactly one non-empty version string (Requirement 9.1: every subcomponent
+  has exactly one recorded version identifier);
+* the invariant ``new_last_sync_commit == pinned_kineto_commit`` holds.
+
+Usage::
+
+    python validate_release_record.py <path/to/release_record.json>
+
+Exits ``0`` when the record is valid, non-zero with a clear message otherwise.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any, List
+
+# Top-level keys every release record must contain.
+REQUIRED_TOP_LEVEL_KEYS = (
+    "release",
+    "target_pytorch",
+    "pinned_kineto_commit",
+    "previous_last_sync_commit",
+    "new_last_sync_commit",
+    "integrated_commits",
+    "subcomponents",
+)
+
+# The subcomponents map must contain exactly these keys, no more, no fewer.
+EXPECTED_SUBCOMPONENTS = ("libaiupti", "aiu_toolkit", "pytorch", "kineto_spyre")
+
+
+class ReleaseRecordError(Exception):
+    """Raised when a release record is malformed or violates the schema."""
+
+
+def load_release_record(path: str) -> Any:
+    """Load and parse a release_record.json file.
+
+    Raises ``ReleaseRecordError`` with a clear message on a missing file or
+    malformed JSON.
+    """
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            text = handle.read()
+    except FileNotFoundError as exc:
+        raise ReleaseRecordError(f"release record not found: {path}") from exc
+    except OSError as exc:
+        raise ReleaseRecordError(f"could not read release record {path}: {exc}") from exc
+
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ReleaseRecordError(
+            f"malformed JSON in {path}: {exc.msg} (line {exc.lineno}, column {exc.colno})"
+        ) from exc
+
+
+def validate_record(record: Any) -> None:
+    """Validate a parsed release record against the schema and invariants.
+
+    Raises ``ReleaseRecordError`` describing the first violation found.
+    """
+    if not isinstance(record, dict):
+        raise ReleaseRecordError(
+            f"release record must be a JSON object, got {type(record).__name__}"
+        )
+
+    # 1. All required top-level keys present.
+    missing = [key for key in REQUIRED_TOP_LEVEL_KEYS if key not in record]
+    if missing:
+        raise ReleaseRecordError(
+            "missing required top-level key(s): " + ", ".join(sorted(missing))
+        )
+
+    # 2. subcomponents map: exactly the four expected keys, each a non-empty version string.
+    subcomponents = record["subcomponents"]
+    if not isinstance(subcomponents, dict):
+        raise ReleaseRecordError(
+            "'subcomponents' must be a JSON object mapping subcomponent -> version"
+        )
+
+    actual_keys = set(subcomponents)
+    expected_keys = set(EXPECTED_SUBCOMPONENTS)
+    missing_subs = expected_keys - actual_keys
+    extra_subs = actual_keys - expected_keys
+    if missing_subs:
+        raise ReleaseRecordError(
+            "missing subcomponent(s): " + ", ".join(sorted(missing_subs))
+        )
+    if extra_subs:
+        raise ReleaseRecordError(
+            "unexpected subcomponent(s): " + ", ".join(sorted(extra_subs))
+        )
+
+    # Each subcomponent maps to exactly one non-empty version string (Req 9.1).
+    for name in EXPECTED_SUBCOMPONENTS:
+        version = subcomponents[name]
+        if not isinstance(version, str):
+            raise ReleaseRecordError(
+                f"subcomponent '{name}' version must be a single string, "
+                f"got {type(version).__name__}"
+            )
+        if version.strip() == "":
+            raise ReleaseRecordError(
+                f"subcomponent '{name}' has an empty version identifier; "
+                "exactly one non-empty version is required (Req 9.1)"
+            )
+
+    # 3. Invariant: new_last_sync_commit == pinned_kineto_commit.
+    pinned = record["pinned_kineto_commit"]
+    new_sync = record["new_last_sync_commit"]
+    if new_sync != pinned:
+        raise ReleaseRecordError(
+            "invariant violated: new_last_sync_commit "
+            f"({new_sync!r}) must equal pinned_kineto_commit ({pinned!r})"
+        )
+
+
+def validate_release_record(path: str) -> None:
+    """Load and validate a release record file. Raises on any problem."""
+    record = load_release_record(path)
+    validate_record(record)
+
+
+def main(argv: List[str]) -> int:
+    if len(argv) != 2:
+        prog = argv[0] if argv else "validate_release_record.py"
+        print(f"usage: {prog} <path/to/release_record.json>", file=sys.stderr)
+        return 2
+
+    path = argv[1]
+    try:
+        validate_release_record(path)
+    except ReleaseRecordError as exc:
+        print(f"ERROR: invalid release record: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"OK: {path} is a valid release record")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tools/trace_validator/__init__.py
+++ b/tools/trace_validator/__init__.py
@@ -1,0 +1,6 @@
+"""Trace validator package for the kineto-spyre 2.12 release pipeline.
+
+This package will hold the pure ``validate_trace`` implementation and its CLI
+wrapper (added by task 6). It is a proper Python package so the validator and
+its tests can be imported and run on any machine with no AIU hardware.
+"""


### PR DESCRIPTION
## Summary

PR 1 of the kineto-spyre 2.12 release pipeline — the git-only upstream sync stage (no AIU hardware required). Includes the release-record scaffolding (previously split into a separate PR, now consolidated here).

### Provenance scaffolding
- `release_record.template.json` — provenance record template (`release`, `target_pytorch`, `pinned_kineto_commit`, `previous/new_last_sync_commit`, `integrated_commits[]`, `subcomponents` map). Upstream kineto is unversioned, so the pin is a commit SHA (no tag field).
- `scripts/validate_release_record.py` — schema/invariant validator + CLI (one non-empty version per subcomponent; `new_last_sync_commit == pinned_kineto_commit`).
- `tools/trace_validator/` — package scaffolding (validator implemented in a later PR).

### Upstream sync (Component 1–3)
- `scripts/resolve_pin.sh` — read `Pinned_Kineto_Commit` from PyTorch `v2.12.0`'s `third_party/kineto` gitlink and verify it is a real/fetchable upstream commit.
- `scripts/sync_upstream.sh` — cherry-pick `LAST_SYNC..PINNED` (`-x --empty=keep`, ascending), preserve empty commits; on conflict report the conflicting SHA first, retain integrated commits, exit non-zero.
- `scripts/record_sync.sh` — extract integrated SHAs from `-x` provenance lines, write `release_record.json`, rewrite the README sync line + 2.12 target.
- `scripts/check_lost_aiu_changes.sh` — guard for AIU-specific changes lost during conflict resolution.

### Tests
Python `unittest` driving the bash scripts against fixture git repos: `test_resolve_pin.py`, `test_sync_upstream.py`, `test_record_sync.py`, `test_validate_release_record.py`. **33 tests passing.**


## Testing
```
cd scripts && python3 -m unittest discover -s . -p 'test_*.py'   # 33 tests, OK
```

## Note
Supersedes #23 (the setup-only PR), which I'll close — its commit is included here.