### PR TITLE
kineto-spyre 2.12: trace validator and generator (PR 3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 .vscode
 .data
 __pycache__
+
+# Hypothesis property-test example database/cache
+.hypothesis/

--- a/scripts/gen_trace.py
+++ b/scripts/gen_trace.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Generate a PyTorch profiler trace over an AIU (PrivateUse1) workload.
+
+This is Component 5 of the kineto-spyre 2.12 release pipeline (the *generator*
+half of the Trace Generator + Validator). It drives the PyTorch profiler over a
+small ``privateuseone`` workload and exports a Chrome-trace JSON that the trace
+validator (``tools/trace_validator``) can then check.
+
+Requirements covered:
+  - Req 3.3: assert the profiler reports PrivateUse1 in its supported activities
+    (sanity check that the wheel was built with PrivateUse1 profiler
+    registration enabled).
+  - Req 7.1: produce a Profiler_Trace by running the profiler.
+  - Req 7.2: the workload exercises the AIU device so that the trace contains at
+    least one AIU Trace_Event.
+
+[needs AIU hardware] to RUN. This script imports ``torch`` and drives a
+PrivateUse1 (AIU) workload, which requires AIU hardware and a kineto-spyre
+enabled PyTorch wheel. The ``torch`` import is kept *inside* :func:`generate_trace`
+so this module can still be imported / byte-compiled on a machine without torch
+installed (e.g. for authoring and CI lint stages that do not have AIU hardware).
+
+Usage:
+    python3 scripts/gen_trace.py [OUTPUT_PATH]
+    GEN_TRACE_OUTPUT=/tmp/trace.json python3 scripts/gen_trace.py
+
+If no output path is given on the command line, the ``GEN_TRACE_OUTPUT``
+environment variable is used, falling back to ``trace.json`` in the current
+working directory.
+"""
+
+import argparse
+import os
+import sys
+
+# Default output path for the exported Chrome trace (Req 7.1). Overridable via a
+# CLI argument or the GEN_TRACE_OUTPUT environment variable.
+DEFAULT_OUTPUT = "trace.json"
+
+# The PrivateUse1 device backend name PyTorch exposes for AIU.
+PRIVATEUSE1_DEVICE = "privateuseone"
+
+
+def resolve_output_path(argv=None):
+    """Resolve the trace output path from CLI args / env / default.
+
+    Pure (no torch needed) so it can be unit-checked without AIU hardware.
+    """
+    parser = argparse.ArgumentParser(
+        description="Generate a PyTorch profiler trace over an AIU "
+        "(PrivateUse1) workload and export it as Chrome-trace JSON.",
+    )
+    parser.add_argument(
+        "output",
+        nargs="?",
+        default=os.environ.get("GEN_TRACE_OUTPUT", DEFAULT_OUTPUT),
+        help="Path to write the exported Chrome trace JSON "
+        "(default: $GEN_TRACE_OUTPUT or %(default)r).",
+    )
+    args = parser.parse_args(argv)
+    return args.output
+
+
+def generate_trace(output_path):
+    """Run the profiler over a PrivateUse1 workload and export the trace.
+
+    torch is imported here (not at module scope) so the module remains
+    importable / byte-compilable without torch installed. Running this function
+    requires AIU hardware and a kineto-spyre enabled PyTorch wheel.
+    """
+    import torch
+    from torch.profiler import ProfilerActivity, profile
+
+    # Req 3.3 sanity check: PrivateUse1 must be a supported profiler activity.
+    # If it is not, the wheel was not built with PrivateUse1 profiler
+    # registration (PR #172154) and no AIU events could ever be emitted.
+    supported = torch.profiler.supported_activities()
+    if not any("PrivateUse1" in str(activity) for activity in supported):
+        raise RuntimeError(
+            "PrivateUse1 is not in torch.profiler.supported_activities() "
+            "({}). The PyTorch wheel was not built with PrivateUse1 profiler "
+            "registration; AIU (PrivateUse1) profiling is unavailable.".format(
+                [str(a) for a in supported]
+            )
+        )
+
+    # Small PrivateUse1 (AIU) workload: a few matmuls on a device tensor so the
+    # profiler records at least one AIU Trace_Event (Req 7.2).
+    device = PRIVATEUSE1_DEVICE
+    with profile(
+        activities=[ProfilerActivity.CPU, ProfilerActivity.PrivateUse1]
+    ) as prof:
+        x = torch.randn(256, 256, device=device)
+        for _ in range(10):
+            x = x @ x
+        # Ensure queued device work has completed before the trace is exported.
+        if hasattr(torch, PRIVATEUSE1_DEVICE):
+            backend = getattr(torch, PRIVATEUSE1_DEVICE)
+            if hasattr(backend, "synchronize"):
+                backend.synchronize()
+
+    # Req 7.1: produce a Profiler_Trace as a Chrome-trace JSON file.
+    prof.export_chrome_trace(output_path)
+    return output_path
+
+
+def main(argv=None):
+    output_path = resolve_output_path(argv)
+    written = generate_trace(output_path)
+    print("Wrote profiler trace to {}".format(written))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_gen_trace.py
+++ b/scripts/test_gen_trace.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Integration test for the AIU trace generator (``scripts/gen_trace.py``).
+
+[needs AIU hardware] to RUN. This test drives the real PyTorch profiler over a
+PrivateUse1 (AIU) workload via ``gen_trace.py`` and then asserts the exported
+``trace.json`` parses and contains at least one AIU Trace_Event.
+
+Requirements covered:
+  - Req 7.1: ``gen_trace.py`` produces a parseable Profiler_Trace.
+  - Req 7.2: the produced trace contains at least one AIU Trace_Event.
+
+The test is SKIPPED (never failed/errored) when the environment cannot run it:
+torch is not importable, or the profiler does not report PrivateUse1 in its
+supported activities (i.e. no AIU hardware / no kineto-spyre enabled wheel). On
+a machine without AIU hardware this is the expected outcome and the test should
+report SKIPPED, not FAILED.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.dirname(HERE)
+GEN_TRACE = os.path.join(HERE, "gen_trace.py")
+
+
+def _aiu_profiling_available():
+    """True only when torch is importable AND PrivateUse1 profiling is supported.
+
+    Any import or runtime error is treated as "not available" so the guard never
+    raises during collection on a torch-less / AIU-less machine.
+    """
+    try:
+        import torch  # noqa: F401
+
+        supported = torch.profiler.supported_activities()
+        return any("PrivateUse1" in str(activity) for activity in supported)
+    except Exception:
+        return False
+
+
+def _is_aiu_event(event):
+    """Return True if a Chrome-trace event represents an AIU (PrivateUse1) activity.
+
+    Prefer the trace validator's canonical ``is_aiu_event`` when it is available
+    in this checkout; otherwise fall back to an inline category check that
+    matches the design's AIU-event definition (``cat`` identifying a
+    PrivateUse1 device activity).
+    """
+    try:
+        from tools.trace_validator import is_aiu_event  # type: ignore
+
+        return is_aiu_event(event)
+    except Exception:
+        category = str(event.get("cat", "")).lower()
+        name = str(event.get("name", "")).lower()
+        return "privateuse1" in category or "aiu" in category or "aiu" in name
+
+
+AIU_AVAILABLE = _aiu_profiling_available()
+
+
+@unittest.skipUnless(
+    AIU_AVAILABLE,
+    "torch / PrivateUse1 (AIU) profiling support unavailable — needs AIU hardware",
+)
+class TestGenTraceIntegration(unittest.TestCase):
+    """End-to-end: run gen_trace.py and validate the produced trace."""
+
+    def test_gen_trace_produces_parseable_trace_with_aiu_event(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out_path = os.path.join(tmp, "trace.json")
+
+            # Run the generator as a subprocess, exactly as CI / the smoke test
+            # would invoke it. Pass the output path as a CLI argument.
+            result = subprocess.run(
+                [sys.executable, GEN_TRACE, out_path],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(
+                result.returncode,
+                0,
+                msg="gen_trace.py failed:\nstdout:\n{}\nstderr:\n{}".format(
+                    result.stdout, result.stderr
+                ),
+            )
+
+            # Req 7.1: the produced trace must parse as JSON.
+            self.assertTrue(
+                os.path.exists(out_path), "gen_trace.py did not write the trace file"
+            )
+            with open(out_path) as fh:
+                trace = json.load(fh)
+
+            events = trace.get("traceEvents", [])
+            self.assertIsInstance(events, list)
+
+            # Req 7.2: at least one AIU Trace_Event must be present.
+            aiu_events = [e for e in events if _is_aiu_event(e)]
+            self.assertGreaterEqual(
+                len(aiu_events),
+                1,
+                msg="trace contained no AIU (PrivateUse1) events",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Tooling package root for the kineto-spyre repository."""

--- a/tools/trace_validator/__init__.py
+++ b/tools/trace_validator/__init__.py
@@ -1,0 +1,37 @@
+"""Trace validator package for the kineto-spyre 2.12 release pipeline.
+
+Provides a pure, hardware-independent validator for Chrome-trace JSON
+produced by the PyTorch profiler (Component 5 of the release design).
+
+Public API:
+    - validate_trace(trace) -> list[Violation]
+    - parse_trace(text) -> dict
+    - load_trace(path) -> dict
+    - is_aiu_event(event) -> bool
+    - is_valid(violations) -> bool
+    - is_failing(violations) -> bool
+    - Violation
+    - TraceParseError
+"""
+
+from .validator import (
+    TraceParseError,
+    Violation,
+    is_aiu_event,
+    is_failing,
+    is_valid,
+    load_trace,
+    parse_trace,
+    validate_trace,
+)
+
+__all__ = [
+    "TraceParseError",
+    "Violation",
+    "is_aiu_event",
+    "is_failing",
+    "is_valid",
+    "load_trace",
+    "parse_trace",
+    "validate_trace",
+]

--- a/tools/trace_validator/__main__.py
+++ b/tools/trace_validator/__main__.py
@@ -1,0 +1,10 @@
+"""Enable ``python -m tools.trace_validator <trace.json>``."""
+
+from __future__ import annotations
+
+import sys
+
+from .cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/trace_validator/cli.py
+++ b/tools/trace_validator/cli.py
@@ -1,0 +1,110 @@
+"""Command-line wrapper for the trace validator (design Component 5, Req 7.8).
+
+Usage::
+
+    python -m tools.trace_validator <trace.json> [<trace2.json> ...]
+
+Loads each trace file, runs :func:`validate_trace`, prints every violated
+check together with the offending event(s), and exits non-zero when any
+violation exists. An empty violation list means the trace is valid and the
+process exits 0.
+
+Exit codes:
+    0  every trace validated cleanly (no violations)
+    1  at least one trace produced one or more violations
+    2  a trace file was malformed / could not be parsed, or was unreadable
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import List, Optional, Sequence
+
+from .validator import (
+    TraceParseError,
+    Violation,
+    is_valid,
+    load_trace,
+    validate_trace,
+)
+
+EXIT_OK = 0
+EXIT_VIOLATIONS = 1
+EXIT_PARSE_ERROR = 2
+
+
+def _event_summary(event: object) -> str:
+    """Render the offending event(s) of a violation compactly for the CLI."""
+    if event is None:
+        return "<whole trace>"
+    if isinstance(event, tuple):
+        return " <-> ".join(_event_summary(e) for e in event)
+    if isinstance(event, dict):
+        name = event.get("name")
+        return (
+            "{{name=%r, ts=%r, dur=%r, pid=%r, tid=%r, cat=%r}}"
+            % (
+                name,
+                event.get("ts"),
+                event.get("dur"),
+                event.get("pid"),
+                event.get("tid"),
+                event.get("cat"),
+            )
+        )
+    return repr(event)
+
+
+def _print_report(path: str, violations: List[Violation], stream=sys.stdout) -> None:
+    if is_valid(violations):
+        print("%s: VALID (no violations)" % path, file=stream)
+        return
+    print(
+        "%s: INVALID (%d violation%s)"
+        % (path, len(violations), "" if len(violations) == 1 else "s"),
+        file=stream,
+    )
+    for v in violations:
+        print(
+            "  - check=%s detail=%s event=%s"
+            % (v.check, v.detail, _event_summary(v.event)),
+            file=stream,
+        )
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m tools.trace_validator",
+        description="Validate a PyTorch/Kineto Chrome-trace JSON file.",
+    )
+    parser.add_argument(
+        "trace",
+        nargs="+",
+        help="path(s) to Chrome-trace JSON file(s) to validate",
+    )
+    args = parser.parse_args(argv)
+
+    exit_code = EXIT_OK
+    for path in args.trace:
+        try:
+            trace = load_trace(path)
+        except TraceParseError as exc:
+            print("%s: PARSE ERROR: %s" % (path, exc), file=sys.stderr)
+            exit_code = max(exit_code, EXIT_PARSE_ERROR)
+            continue
+        except OSError as exc:
+            print("%s: cannot read file: %s" % (path, exc), file=sys.stderr)
+            exit_code = max(exit_code, EXIT_PARSE_ERROR)
+            continue
+
+        violations = validate_trace(trace)
+        _print_report(path, violations)
+        if not is_valid(violations):
+            exit_code = max(exit_code, EXIT_VIOLATIONS)
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/trace_validator/tests/__init__.py
+++ b/tools/trace_validator/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the trace validator package."""

--- a/tools/trace_validator/tests/strategies.py
+++ b/tools/trace_validator/tests/strategies.py
@@ -1,0 +1,148 @@
+"""Shared Hypothesis generators and oracle helpers for the validator property tests.
+
+The generator emits randomized Chrome-trace structures that exercise the full
+validator input space described in the design's "Correctness Properties":
+
+    - random counts of complete (``ph == "X"``) events (plus some non-``X``
+      events that the validator must ignore),
+    - random ``(pid, tid)`` thread assignments drawn from a small pool so that
+      same-thread collisions are common,
+    - random ``ts``/``dur`` over a small integer range that includes zero,
+      negative, and boundary-touching values,
+    - a random subset of events marked as AIU via the ``cat`` field, and
+    - random omission / null-ing of ``name``/``ts``/``dur`` to exercise
+      malformedness.
+
+The module also exposes small *independent* oracle helpers used by the tests
+to compute the expected validation outcome without reusing the validator's own
+implementation, so each property asserts a genuine iff.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from hypothesis import strategies as st
+
+# Small pools so that same-(pid, tid) collisions happen frequently.
+_PIDS = st.integers(min_value=0, max_value=2)
+_TIDS = st.integers(min_value=0, max_value=2)
+
+# Names, timestamps and durations. The -5..20 integer range makes touching and
+# overlapping intervals (and zero / negative timing) common.
+_NAMES = st.sampled_from(["k", "matmul", "add", "kernel_a", "relu"])
+_TS_VALUES = st.integers(min_value=-5, max_value=20)
+_DUR_VALUES = st.integers(min_value=-5, max_value=20)
+
+_AIU_CATS = ["privateuse1", "PrivateUse1", "AIU", "aiu"]
+_NON_AIU_CATS = ["cpu_op", "user_annotation", "Runtime", "python_function"]
+
+# Mostly complete ("X") events, with some other phases mixed in so the
+# validator's ph filtering is exercised.
+_PH_VALUES = st.sampled_from(["X", "X", "X", "X", "i", "M", "B", "E"])
+
+# Field presence: weighted toward "present" so valid-ish events also appear.
+_FIELD_STATE = st.sampled_from(["present", "present", "present", "null", "omit"])
+
+# Category state: a mix of AIU, non-AIU, null and omitted categories.
+_CAT_STATE = st.sampled_from(
+    _AIU_CATS + _NON_AIU_CATS + [None, "__omit__"]
+)
+
+
+@st.composite
+def events(draw) -> Dict[str, Any]:
+    """Draw a single randomized Chrome-trace event object."""
+    event: Dict[str, Any] = {
+        "ph": draw(_PH_VALUES),
+        "pid": draw(_PIDS),
+        "tid": draw(_TIDS),
+    }
+
+    cat = draw(_CAT_STATE)
+    if cat != "__omit__":
+        event["cat"] = cat
+
+    name_state = draw(_FIELD_STATE)
+    if name_state == "present":
+        event["name"] = draw(_NAMES)
+    elif name_state == "null":
+        event["name"] = None
+
+    ts_state = draw(_FIELD_STATE)
+    if ts_state == "present":
+        event["ts"] = draw(_TS_VALUES)
+    elif ts_state == "null":
+        event["ts"] = None
+
+    dur_state = draw(_FIELD_STATE)
+    if dur_state == "present":
+        event["dur"] = draw(_DUR_VALUES)
+    elif dur_state == "null":
+        event["dur"] = None
+
+    return event
+
+
+@st.composite
+def traces(draw, min_events: int = 0, max_events: int = 8) -> Dict[str, Any]:
+    """Draw a randomized Chrome-trace document ``{"traceEvents": [...]}``."""
+    n = draw(st.integers(min_value=min_events, max_value=max_events))
+    return {"traceEvents": [draw(events()) for _ in range(n)]}
+
+
+# ---------------------------------------------------------------------------
+# Independent oracle helpers (do NOT call the validator implementation)
+# ---------------------------------------------------------------------------
+
+_AIU_CAT_SET = {"privateuse1", "aiu"}
+
+
+def oracle_complete_events(trace: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """The complete (``ph == "X"``) events, mirroring the validator's filter."""
+    return [
+        e
+        for e in trace["traceEvents"]
+        if isinstance(e, dict) and e.get("ph") == "X"
+    ]
+
+
+def oracle_is_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def oracle_is_aiu(event: Dict[str, Any]) -> bool:
+    cat = event.get("cat")
+    return isinstance(cat, str) and cat.strip().lower() in _AIU_CAT_SET
+
+
+def oracle_overlap(a: Dict[str, Any], b: Dict[str, Any]) -> bool:
+    """Independent half-open ``[ts, ts+dur)`` intersection test."""
+    a_ts, a_dur, b_ts, b_dur = (
+        a.get("ts"),
+        a.get("dur"),
+        b.get("ts"),
+        b.get("dur"),
+    )
+    for v in (a_ts, a_dur, b_ts, b_dur):
+        if not oracle_is_number(v):
+            return False
+    return a_ts < b_ts + b_dur and b_ts < a_ts + a_dur
+
+
+def oracle_overlapping_pairs(
+    trace: Dict[str, Any]
+) -> List[Tuple[int, int]]:
+    """Indices of same-thread complete-event pairs whose intervals intersect."""
+    evs = oracle_complete_events(trace)
+    pairs: List[Tuple[int, int]] = []
+    for i in range(len(evs)):
+        for j in range(i + 1, len(evs)):
+            a, b = evs[i], evs[j]
+            same_thread = (a.get("pid"), a.get("tid")) == (
+                b.get("pid"),
+                b.get("tid"),
+            )
+            if same_thread and oracle_overlap(a, b):
+                pairs.append((i, j))
+    return pairs

--- a/tools/trace_validator/tests/test_cli.py
+++ b/tools/trace_validator/tests/test_cli.py
@@ -1,0 +1,51 @@
+"""Unit tests for the validator CLI wrapper (task 6.2, Req 7.8)."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+
+from tools.trace_validator import cli
+
+GOOD = {
+    "traceEvents": [
+        {"name": "k", "ph": "X", "ts": 100, "dur": 10, "pid": 1, "tid": 7, "cat": "privateuse1"},
+    ]
+}
+
+BAD = {
+    "traceEvents": [
+        {"name": "k", "ph": "X", "ts": 0, "dur": 10, "pid": 1, "tid": 7, "cat": "privateuse1"},
+    ]
+}
+
+
+class CliTests(unittest.TestCase):
+    def _write(self, obj_or_text):
+        fd, path = tempfile.mkstemp(suffix=".json")
+        self.addCleanup(lambda: os.path.exists(path) and os.unlink(path))
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            if isinstance(obj_or_text, str):
+                fh.write(obj_or_text)
+            else:
+                json.dump(obj_or_text, fh)
+        return path
+
+    def test_valid_trace_exits_zero(self):
+        self.assertEqual(cli.main([self._write(GOOD)]), cli.EXIT_OK)
+
+    def test_invalid_trace_exits_nonzero(self):
+        self.assertEqual(cli.main([self._write(BAD)]), cli.EXIT_VIOLATIONS)
+
+    def test_malformed_file_exits_parse_error(self):
+        self.assertEqual(cli.main([self._write("{ not json")]), cli.EXIT_PARSE_ERROR)
+
+    def test_multiple_traces_worst_exit_code_wins(self):
+        rc = cli.main([self._write(GOOD), self._write(BAD)])
+        self.assertEqual(rc, cli.EXIT_VIOLATIONS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/trace_validator/tests/test_examples_fixtures.py
+++ b/tools/trace_validator/tests/test_examples_fixtures.py
@@ -1,0 +1,183 @@
+"""Example / edge-case fixtures for the trace validator (task 6.8).
+
+Deterministic tests over known traces asserting the exact set of violated
+checks (or the lack of any). Covers a known-good golden trace, an empty trace,
+an all-CPU (no AIU) trace, overlapping AIU kernels on one thread, a zero-``ts``
+event, a zero-``dur`` completed event, and a null ``name`` event.
+
+Validates: Requirements 7.2, 7.3, 7.4, 7.5, 7.6, 7.8
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+
+from tools.trace_validator.validator import (
+    TraceParseError,
+    is_failing,
+    is_valid,
+    load_trace,
+    parse_trace,
+    validate_trace,
+)
+
+
+def _checks(violations):
+    return sorted({v.check for v in violations})
+
+
+# A known-good golden trace: one CPU op and two serial AIU kernels (disjoint
+# intervals) on the same thread, all well-formed, positive timing.
+GOLDEN_TRACE = {
+    "traceEvents": [
+        {"name": "cpu_op", "ph": "X", "ts": 10, "dur": 5, "pid": 1, "tid": 1, "cat": "cpu_op"},
+        {"name": "aiu_matmul", "ph": "X", "ts": 100, "dur": 10, "pid": 1, "tid": 7, "cat": "privateuse1"},
+        {"name": "aiu_add", "ph": "X", "ts": 120, "dur": 8, "pid": 1, "tid": 7, "cat": "PrivateUse1"},
+        # A non-complete event that must be ignored by the validator.
+        {"name": "meta", "ph": "M", "pid": 1, "tid": 7},
+    ]
+}
+
+
+class GoldenTrace(unittest.TestCase):
+    def test_golden_trace_has_no_violations_and_is_valid(self):
+        violations = validate_trace(GOLDEN_TRACE)
+        self.assertEqual(violations, [])
+        self.assertTrue(is_valid(violations))
+        self.assertFalse(is_failing(violations))
+
+    def test_touching_intervals_do_not_overlap(self):
+        # Half-open [ts, ts+dur): event ending at 110 and one starting at 110
+        # on the same thread must NOT be a no_overlap violation.
+        trace = {
+            "traceEvents": [
+                {"name": "a", "ph": "X", "ts": 100, "dur": 10, "pid": 1, "tid": 7, "cat": "privateuse1"},
+                {"name": "b", "ph": "X", "ts": 110, "dur": 10, "pid": 1, "tid": 7, "cat": "privateuse1"},
+            ]
+        }
+        self.assertEqual(validate_trace(trace), [])
+
+
+class EmptyTrace(unittest.TestCase):
+    def test_empty_trace_fails_at_least_one_aiu_only(self):
+        violations = validate_trace({"traceEvents": []})
+        self.assertEqual(_checks(violations), ["at_least_one_aiu"])
+        self.assertFalse(is_valid(violations))
+
+
+class AllCpuTrace(unittest.TestCase):
+    def test_all_cpu_trace_fails_at_least_one_aiu(self):
+        trace = {
+            "traceEvents": [
+                {"name": "cpu_a", "ph": "X", "ts": 1, "dur": 2, "pid": 1, "tid": 1, "cat": "cpu_op"},
+                {"name": "cpu_b", "ph": "X", "ts": 5, "dur": 2, "pid": 1, "tid": 1, "cat": "user_annotation"},
+            ]
+        }
+        violations = validate_trace(trace)
+        self.assertEqual(_checks(violations), ["at_least_one_aiu"])
+
+
+class OverlappingAiuKernels(unittest.TestCase):
+    def test_overlapping_aiu_kernels_same_thread_report_no_overlap(self):
+        trace = {
+            "traceEvents": [
+                {"name": "k1", "ph": "X", "ts": 100, "dur": 50, "pid": 1, "tid": 7, "cat": "privateuse1"},
+                {"name": "k2", "ph": "X", "ts": 120, "dur": 50, "pid": 1, "tid": 7, "cat": "privateuse1"},
+            ]
+        }
+        violations = validate_trace(trace)
+        self.assertIn("no_overlap", _checks(violations))
+        no_overlap = [v for v in violations if v.check == "no_overlap"]
+        self.assertEqual(len(no_overlap), 1)
+        self.assertIsInstance(no_overlap[0].event, tuple)
+
+    def test_overlap_on_different_threads_is_allowed(self):
+        trace = {
+            "traceEvents": [
+                {"name": "k1", "ph": "X", "ts": 100, "dur": 50, "pid": 1, "tid": 7, "cat": "privateuse1"},
+                {"name": "k2", "ph": "X", "ts": 120, "dur": 50, "pid": 1, "tid": 8, "cat": "privateuse1"},
+            ]
+        }
+        self.assertEqual(validate_trace(trace), [])
+
+
+class ZeroTimestamp(unittest.TestCase):
+    def test_zero_ts_aiu_event_fails_ts_positive(self):
+        trace = {
+            "traceEvents": [
+                {"name": "k", "ph": "X", "ts": 0, "dur": 10, "pid": 1, "tid": 7, "cat": "privateuse1"},
+            ]
+        }
+        violations = validate_trace(trace)
+        self.assertEqual(_checks(violations), ["ts_positive"])
+
+
+class ZeroDuration(unittest.TestCase):
+    def test_zero_dur_completed_aiu_event_fails_dur_positive(self):
+        trace = {
+            "traceEvents": [
+                {"name": "k", "ph": "X", "ts": 100, "dur": 0, "pid": 1, "tid": 7, "cat": "privateuse1"},
+            ]
+        }
+        violations = validate_trace(trace)
+        self.assertEqual(_checks(violations), ["dur_positive"])
+
+
+class NullName(unittest.TestCase):
+    def test_null_name_fails_well_formed(self):
+        trace = {
+            "traceEvents": [
+                {"name": None, "ph": "X", "ts": 100, "dur": 10, "pid": 1, "tid": 7, "cat": "privateuse1"},
+            ]
+        }
+        violations = validate_trace(trace)
+        self.assertIn("well_formed", _checks(violations))
+        wf = [v for v in violations if v.check == "well_formed"]
+        self.assertEqual(len(wf), 1)
+
+    def test_missing_ts_and_dur_report_two_well_formed_violations(self):
+        trace = {
+            "traceEvents": [
+                {"name": "k", "ph": "X", "pid": 1, "tid": 7, "cat": "privateuse1"},
+            ]
+        }
+        violations = validate_trace(trace)
+        wf = [v for v in violations if v.check == "well_formed"]
+        self.assertEqual(len(wf), 2)  # missing ts and missing dur
+
+
+class ParseErrors(unittest.TestCase):
+    def test_malformed_json_raises_parse_error(self):
+        with self.assertRaises(TraceParseError):
+            parse_trace("{ this is not json ")
+
+    def test_non_object_top_level_raises_parse_error(self):
+        with self.assertRaises(TraceParseError):
+            parse_trace("[1, 2, 3]")
+
+    def test_missing_trace_events_raises_parse_error(self):
+        with self.assertRaises(TraceParseError):
+            parse_trace('{"foo": "bar"}')
+
+    def test_parseable_but_invalid_trace_does_not_raise(self):
+        # An empty trace is parseable; it must return violations, not raise.
+        trace = parse_trace('{"traceEvents": []}')
+        violations = validate_trace(trace)
+        self.assertTrue(is_failing(violations))
+
+    def test_load_trace_roundtrip(self):
+        fd, path = tempfile.mkstemp(suffix=".json")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump(GOLDEN_TRACE, fh)
+            loaded = load_trace(path)
+            self.assertEqual(validate_trace(loaded), [])
+        finally:
+            os.unlink(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/trace_validator/tests/test_property_1_no_overlap.py
+++ b/tools/trace_validator/tests/test_property_1_no_overlap.py
@@ -1,0 +1,46 @@
+# Feature: kineto-spyre-2-12-release, Property 1: Same-thread non-concurrent events do not overlap
+"""Property 1: Same-thread non-concurrent events do not overlap.
+
+Validates: Requirements 7.3
+
+For any generated trace, ``validate_trace`` reports a ``no_overlap`` violation
+if and only if there exist two events on the same ``(pid, tid)`` thread whose
+(non-concurrent, serial) intervals ``[ts, ts+dur)`` intersect; when all
+same-thread intervals are disjoint, no ``no_overlap`` violation is reported.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from hypothesis import given, settings
+
+from tools.trace_validator.tests.strategies import oracle_overlapping_pairs, traces
+from tools.trace_validator.validator import validate_trace
+
+
+class Property1NoOverlap(unittest.TestCase):
+    @settings(max_examples=200)
+    @given(trace=traces())
+    def test_no_overlap_reported_iff_same_thread_intervals_intersect(self, trace):
+        violations = validate_trace(trace)
+        no_overlap = [v for v in violations if v.check == "no_overlap"]
+
+        expected_pairs = oracle_overlapping_pairs(trace)
+
+        # iff: a no_overlap violation exists exactly when an overlapping
+        # same-thread pair exists.
+        self.assertEqual(bool(no_overlap), bool(expected_pairs))
+
+        # Completeness: one no_overlap violation per overlapping same-thread pair.
+        self.assertEqual(len(no_overlap), len(expected_pairs))
+
+        # Soundness: every reported no_overlap names exactly the two offending
+        # events as a pair.
+        for v in no_overlap:
+            self.assertIsInstance(v.event, tuple)
+            self.assertEqual(len(v.event), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/trace_validator/tests/test_property_2_aiu_positivity.py
+++ b/tools/trace_validator/tests/test_property_2_aiu_positivity.py
@@ -1,0 +1,57 @@
+# Feature: kineto-spyre-2-12-release, Property 2: AIU timing positivity
+"""Property 2: AIU timing positivity.
+
+Validates: Requirements 7.4, 7.5
+
+For any generated trace, ``validate_trace`` reports a ``ts_positive`` violation
+for exactly those AIU events whose numeric ``ts <= 0`` and a ``dur_positive``
+violation for exactly those AIU events whose numeric ``dur <= 0``.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from hypothesis import given, settings
+
+from tools.trace_validator.tests.strategies import (
+    oracle_complete_events,
+    oracle_is_aiu,
+    oracle_is_number,
+    traces,
+)
+from tools.trace_validator.validator import validate_trace
+
+
+class Property2AiuPositivity(unittest.TestCase):
+    @settings(max_examples=200)
+    @given(trace=traces())
+    def test_positivity_violation_iff_aiu_event_has_nonpositive_timing(self, trace):
+        violations = validate_trace(trace)
+        ts_viol = [v for v in violations if v.check == "ts_positive"]
+        dur_viol = [v for v in violations if v.check == "dur_positive"]
+
+        aiu = [e for e in oracle_complete_events(trace) if oracle_is_aiu(e)]
+        expected_ts = [
+            e for e in aiu if oracle_is_number(e.get("ts")) and e.get("ts") <= 0
+        ]
+        expected_dur = [
+            e for e in aiu if oracle_is_number(e.get("dur")) and e.get("dur") <= 0
+        ]
+
+        # Completeness + soundness via exact count match.
+        self.assertEqual(len(ts_viol), len(expected_ts))
+        self.assertEqual(len(dur_viol), len(expected_dur))
+
+        # iff at the trace level.
+        self.assertEqual(bool(ts_viol), bool(expected_ts))
+        self.assertEqual(bool(dur_viol), bool(expected_dur))
+
+        # Each positivity violation names a single AIU event.
+        for v in ts_viol + dur_viol:
+            self.assertIsInstance(v.event, dict)
+            self.assertTrue(oracle_is_aiu(v.event))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/trace_validator/tests/test_property_3_well_formed.py
+++ b/tools/trace_validator/tests/test_property_3_well_formed.py
@@ -1,0 +1,46 @@
+# Feature: kineto-spyre-2-12-release, Property 3: Event well-formedness
+"""Property 3: Event well-formedness.
+
+Validates: Requirements 7.6
+
+For any generated trace, ``validate_trace`` reports a ``well_formed`` violation
+for exactly those complete events missing or having a null ``name``, ``ts``, or
+``dur``, and reports none when every complete event carries all three as
+present, non-null values.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from hypothesis import given, settings
+
+from tools.trace_validator.tests.strategies import oracle_complete_events, traces
+from tools.trace_validator.validator import validate_trace
+
+
+class Property3WellFormed(unittest.TestCase):
+    @settings(max_examples=200)
+    @given(trace=traces())
+    def test_well_formed_violation_iff_missing_or_null_required_attr(self, trace):
+        violations = validate_trace(trace)
+        wf = [v for v in violations if v.check == "well_formed"]
+
+        # Oracle: one violation per (event, attr) where the attr is None/absent.
+        expected_count = 0
+        any_malformed = False
+        for e in oracle_complete_events(trace):
+            for attr in ("name", "ts", "dur"):
+                if e.get(attr) is None:
+                    expected_count += 1
+                    any_malformed = True
+
+        self.assertEqual(len(wf), expected_count)
+        self.assertEqual(bool(wf), any_malformed)
+
+        for v in wf:
+            self.assertIsInstance(v.event, dict)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/trace_validator/tests/test_property_4_at_least_one_aiu.py
+++ b/tools/trace_validator/tests/test_property_4_at_least_one_aiu.py
@@ -1,0 +1,44 @@
+# Feature: kineto-spyre-2-12-release, Property 4: At least one AIU event required
+"""Property 4: At least one AIU event required.
+
+Validates: Requirements 7.2, 7.7
+
+For any generated trace, the ``at_least_one_aiu`` check fails if and only if
+the trace contains no AIU complete event; any trace containing one or more AIU
+events passes this check.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from hypothesis import given, settings
+
+from tools.trace_validator.tests.strategies import (
+    oracle_complete_events,
+    oracle_is_aiu,
+    traces,
+)
+from tools.trace_validator.validator import validate_trace
+
+
+class Property4AtLeastOneAiu(unittest.TestCase):
+    @settings(max_examples=200)
+    @given(trace=traces())
+    def test_at_least_one_aiu_fails_iff_no_aiu_events(self, trace):
+        violations = validate_trace(trace)
+        aiu_viol = [v for v in violations if v.check == "at_least_one_aiu"]
+
+        has_aiu = any(oracle_is_aiu(e) for e in oracle_complete_events(trace))
+
+        # iff: the check fails exactly when there are no AIU events.
+        self.assertEqual(bool(aiu_viol), not has_aiu)
+
+        # When it fails, it fails exactly once and refers to the whole trace.
+        if not has_aiu:
+            self.assertEqual(len(aiu_viol), 1)
+            self.assertIsNone(aiu_viol[0].event)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/trace_validator/tests/test_property_5_soundness_completeness.py
+++ b/tools/trace_validator/tests/test_property_5_soundness_completeness.py
@@ -1,0 +1,95 @@
+# Feature: kineto-spyre-2-12-release, Property 5: Validator soundness and completeness
+"""Property 5: Validator soundness and completeness.
+
+Validates: Requirements 7.8, 7.9
+
+For any generated trace, ``validate_trace`` returns an empty violation list if
+and only if the trace satisfies all of Properties 1-4. Whenever the list is
+non-empty, every entry identifies a known check and the offending event(s), the
+trace is not reported valid, and the "valid"/"failing" indicators are mutually
+exclusive exactly when at least one check fails.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from hypothesis import given, settings
+
+from tools.trace_validator.tests.strategies import (
+    oracle_complete_events,
+    oracle_is_aiu,
+    oracle_is_number,
+    oracle_overlapping_pairs,
+    traces,
+)
+from tools.trace_validator.validator import (
+    KNOWN_CHECKS,
+    is_failing,
+    is_valid,
+    validate_trace,
+)
+
+
+def _oracle_satisfies_all(trace) -> bool:
+    """True iff the trace independently satisfies Properties 1-4."""
+    events = oracle_complete_events(trace)
+
+    # Property 3: every complete event well-formed.
+    for e in events:
+        for attr in ("name", "ts", "dur"):
+            if e.get(attr) is None:
+                return False
+
+    aiu = [e for e in events if oracle_is_aiu(e)]
+
+    # Property 4: at least one AIU event.
+    if not aiu:
+        return False
+
+    # Property 2: AIU timing positivity.
+    for e in aiu:
+        if oracle_is_number(e.get("ts")) and e.get("ts") <= 0:
+            return False
+        if oracle_is_number(e.get("dur")) and e.get("dur") <= 0:
+            return False
+
+    # Property 1: no same-thread interval overlap.
+    if oracle_overlapping_pairs(trace):
+        return False
+
+    return True
+
+
+class Property5SoundnessCompleteness(unittest.TestCase):
+    @settings(max_examples=200)
+    @given(trace=traces())
+    def test_empty_iff_all_properties_hold_and_entries_well_identified(self, trace):
+        violations = validate_trace(trace)
+
+        # Soundness + completeness: empty list iff the trace satisfies all checks.
+        self.assertEqual(len(violations) == 0, _oracle_satisfies_all(trace))
+
+        # Every entry identifies a known check and the offending event(s).
+        for v in violations:
+            self.assertIn(v.check, KNOWN_CHECKS)
+            if v.check == "at_least_one_aiu":
+                self.assertIsNone(v.event)
+            elif v.check == "no_overlap":
+                self.assertIsInstance(v.event, tuple)
+                self.assertEqual(len(v.event), 2)
+            else:
+                self.assertIsInstance(v.event, dict)
+
+        # Req 7.9: a non-empty list forbids reporting valid; the indicators are
+        # mutually exclusive exactly when at least one check fails.
+        if violations:
+            self.assertTrue(is_failing(violations))
+            self.assertFalse(is_valid(violations))
+        else:
+            self.assertTrue(is_valid(violations))
+            self.assertFalse(is_failing(violations))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/trace_validator/validator.py
+++ b/tools/trace_validator/validator.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 # ---------------------------------------------------------------------------
 # Data models

--- a/tools/trace_validator/validator.py
+++ b/tools/trace_validator/validator.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union
 
 # ---------------------------------------------------------------------------
 # Data models

--- a/tools/trace_validator/validator.py
+++ b/tools/trace_validator/validator.py
@@ -1,0 +1,283 @@
+"""Pure trace validator for kineto-spyre Profiler_Traces (design Component 5).
+
+This module implements the release validation checks of Requirement 7 as a
+pure function from a parsed Chrome-trace JSON document to a list of
+``Violation`` records. It performs no I/O beyond an optional file-loading
+helper and requires no AIU hardware, which is exactly why it is the part of
+the release pipeline amenable to property-based testing (design "Correctness
+Properties", Properties 1-5).
+
+Chrome-trace shape::
+
+    {"traceEvents": [{"name", "ts", "dur", "pid", "tid", "cat", "ph", ...}, ...]}
+
+Validation operates over *complete* events (``ph == "X"``) only. Each complete
+event models a recorded/completed activity with a timestamp (``ts``,
+microseconds) and a duration (``dur``).
+
+Checks implemented (Req 7.3-7.9):
+    - ``well_formed``        -- ``name``/``ts``/``dur`` present and non-null (7.6)
+    - ``at_least_one_aiu``   -- the trace has >= 1 AIU event (7.2/7.7)
+    - ``ts_positive``        -- every AIU event has ``ts > 0`` (7.4)
+    - ``dur_positive``       -- every AIU event has ``dur > 0`` (7.5)
+    - ``no_overlap``         -- non-concurrent same-thread events do not
+                                intersect on ``[ts, ts + dur)`` (7.3)
+
+Malformed top-level JSON is distinguished from a parseable-but-invalid trace:
+``parse_trace`` raises ``TraceParseError`` on JSON that cannot be parsed (or
+that lacks a ``traceEvents`` list), whereas ``validate_trace`` never raises for
+a structurally valid trace -- it returns a (possibly empty) violation list
+(Req 7.8).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+# The check names this validator can emit. Every Violation.check is one of
+# these (used by Property 5 to assert each entry names a *known* check).
+KNOWN_CHECKS = frozenset(
+    {
+        "well_formed",
+        "at_least_one_aiu",
+        "ts_positive",
+        "dur_positive",
+        "no_overlap",
+    }
+)
+
+# Category strings (compared case-insensitively) that mark an event as an AIU
+# (PrivateUse1) device activity. PyTorch exposes the AIU device as the
+# "PrivateUse1" backend; both spellings are accepted and documented here.
+_AIU_CATEGORIES = frozenset({"privateuse1", "aiu"})
+
+# Event = a single Chrome-trace JSON object (a dict). A Violation's `event`
+# field carries the offending event, a tuple of events (for `no_overlap`), or
+# ``None`` (for `at_least_one_aiu`, which is about the trace as a whole).
+Event = Dict[str, Any]
+ViolationEvent = Union[Event, Tuple[Event, ...], None]
+
+
+@dataclass(frozen=True)
+class Violation:
+    """A single failed validation check.
+
+    Attributes:
+        check:  the name of the violated check (one of ``KNOWN_CHECKS``).
+        event:  the offending event(s) -- a single event dict, a tuple of
+                events (``no_overlap`` reports the intersecting pair), or
+                ``None`` when the violation is about the trace as a whole
+                (``at_least_one_aiu``).
+        detail: a short human-readable explanation.
+    """
+
+    check: str
+    event: ViolationEvent
+    detail: str
+
+
+class TraceParseError(Exception):
+    """Raised when the top-level trace document is malformed/unparseable.
+
+    This is distinct from a parseable-but-invalid trace: an invalid trace is
+    reported via the violation list returned by :func:`validate_trace`, never
+    by raising.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Parsing / loading
+# ---------------------------------------------------------------------------
+
+
+def parse_trace(text: str) -> Dict[str, Any]:
+    """Parse Chrome-trace JSON text into a trace dict.
+
+    Raises:
+        TraceParseError: if ``text`` is not valid JSON, is not a JSON object,
+            or does not contain a ``traceEvents`` list. These are *malformed*
+            documents (as opposed to parseable-but-invalid traces).
+    """
+    try:
+        data = json.loads(text)
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise TraceParseError(f"malformed trace JSON: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise TraceParseError(
+            f"trace top-level must be a JSON object, got {type(data).__name__}"
+        )
+    if not isinstance(data.get("traceEvents"), list):
+        raise TraceParseError("trace is missing a 'traceEvents' list")
+    return data
+
+
+def load_trace(path: str) -> Dict[str, Any]:
+    """Load and parse a trace file from ``path``.
+
+    Raises:
+        TraceParseError: if the file content is malformed (see ``parse_trace``).
+    """
+    with open(path, "r", encoding="utf-8") as fh:
+        return parse_trace(fh.read())
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def is_aiu_event(event: Event) -> bool:
+    """Return True if ``event`` is an AIU (PrivateUse1) device activity.
+
+    An AIU event is identified by its ``cat`` (category) field. The category
+    is matched case-insensitively against the known AIU category names
+    (``"privateuse1"`` / ``"aiu"``), so ``"PrivateUse1"``, ``"privateuse1"``
+    and ``"AIU"`` all identify an AIU event.
+    """
+    cat = event.get("cat")
+    if not isinstance(cat, str):
+        return False
+    return cat.strip().lower() in _AIU_CATEGORIES
+
+
+def _is_number(value: Any) -> bool:
+    """True if ``value`` is a real number (and not a bool, which is an int)."""
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _complete_events(trace: Dict[str, Any]) -> List[Event]:
+    """Return the complete (``ph == "X"``) event objects from a trace."""
+    return [
+        e
+        for e in trace["traceEvents"]
+        if isinstance(e, dict) and e.get("ph") == "X"
+    ]
+
+
+def intervals_overlap(a: Event, b: Event) -> bool:
+    """True if the half-open intervals ``[ts, ts + dur)`` of ``a`` and ``b`` intersect.
+
+    Uses half-open semantics: two events that merely *touch* (one ends exactly
+    when the other begins) do not overlap. Events whose ``ts``/``dur`` are
+    missing/null/non-numeric are treated as non-overlapping here; their
+    structural problem is reported separately by the ``well_formed`` check.
+    """
+    a_ts, a_dur = a.get("ts"), a.get("dur")
+    b_ts, b_dur = b.get("ts"), b.get("dur")
+    if not (_is_number(a_ts) and _is_number(a_dur)):
+        return False
+    if not (_is_number(b_ts) and _is_number(b_dur)):
+        return False
+    a_start, a_end = a_ts, a_ts + a_dur
+    b_start, b_end = b_ts, b_ts + b_dur
+    # Half-open [start, end) intersection.
+    return a_start < b_end and b_start < a_end
+
+
+def _thread_key(event: Event) -> Tuple[Any, Any]:
+    """The ``(pid, tid)`` thread identity of an event."""
+    return (event.get("pid"), event.get("tid"))
+
+
+# ---------------------------------------------------------------------------
+# Core validation
+# ---------------------------------------------------------------------------
+
+
+def validate_trace(trace: Dict[str, Any]) -> List[Violation]:
+    """Validate a parsed Chrome-trace ``trace`` dict against Requirement 7.
+
+    Returns a list of :class:`Violation`. An empty list means no check failed
+    (the trace MAY be reported valid, Req 7.9). A non-empty list both forbids
+    reporting the trace as valid and identifies, per entry, the violated check
+    and the offending event(s) (Req 7.8).
+
+    This function does not raise for a parseable-but-invalid trace. It does
+    raise ``TraceParseError`` only if handed a structurally malformed object
+    (no ``traceEvents`` list), mirroring ``parse_trace`` for defensive use.
+    """
+    if not isinstance(trace, dict) or not isinstance(trace.get("traceEvents"), list):
+        raise TraceParseError("validate_trace requires a dict with a 'traceEvents' list")
+
+    events = _complete_events(trace)
+    violations: List[Violation] = []
+
+    # --- Req 7.6: each event well-formed (name, ts, dur present & non-null) ---
+    for e in events:
+        for attr in ("name", "ts", "dur"):
+            if e.get(attr) is None:
+                violations.append(
+                    Violation("well_formed", e, "missing or null '%s'" % attr)
+                )
+
+    aiu_events = [e for e in events if is_aiu_event(e)]
+
+    # --- Req 7.2 / 7.7: at least one AIU event ---
+    if not aiu_events:
+        violations.append(
+            Violation("at_least_one_aiu", None, "trace contains no AIU events")
+        )
+
+    # --- Req 7.4 / 7.5: AIU device activities have ts > 0 and dur > 0 ---
+    # Positivity is orthogonal to well-formedness: only numeric values are
+    # checked here; null/missing values are reported by `well_formed` above.
+    for e in aiu_events:
+        ts = e.get("ts")
+        if _is_number(ts) and ts <= 0:
+            violations.append(Violation("ts_positive", e, "AIU event ts <= 0"))
+        dur = e.get("dur")
+        if _is_number(dur) and dur <= 0:
+            violations.append(Violation("dur_positive", e, "AIU event dur <= 0"))
+
+    # --- Req 7.3: no overlap on the same thread for non-concurrent activities ---
+    # Complete ('X') events on a single (pid, tid) thread model serial,
+    # non-concurrent activities (the generated traces carry no parallelism
+    # annotation), so any intersection of their [ts, ts+dur) intervals is a
+    # violation. Touching intervals (half-open) are allowed.
+    by_thread: Dict[Tuple[Any, Any], List[Event]] = {}
+    for e in events:
+        by_thread.setdefault(_thread_key(e), []).append(e)
+
+    for thread_events in by_thread.values():
+        n = len(thread_events)
+        for i in range(n):
+            for j in range(i + 1, n):
+                a, b = thread_events[i], thread_events[j]
+                if intervals_overlap(a, b):
+                    violations.append(
+                        Violation(
+                            "no_overlap",
+                            (a, b),
+                            "same-thread intervals intersect",
+                        )
+                    )
+
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Result indicators (Req 7.8 / 7.9)
+# ---------------------------------------------------------------------------
+
+
+def is_failing(violations: List[Violation]) -> bool:
+    """True when at least one check failed (a non-empty violation list)."""
+    return len(violations) > 0
+
+
+def is_valid(violations: List[Violation]) -> bool:
+    """Whether the trace may be reported valid.
+
+    ``valid`` and ``failing`` are independent indicators derived from the
+    single violation list (Req 7.9). A non-empty list forbids reporting valid;
+    an empty list permits it. The mutual exclusion between "valid" and
+    "failing" therefore holds exactly when one or more checks actually fail.
+    """
+    return len(violations) == 0


### PR DESCRIPTION
## Summary

PR 3 of the kineto-spyre 2.12 release pipeline — Component 5 (Trace Generator + Validator). The validator is fully hardware-independent; the generator requires AIU hardware only to run.

### Trace validator — `tools/trace_validator/`
- `validator.py` — pure `validate_trace(trace) -> [Violation]` over complete (`ph == "X"`) events: `well_formed` (name/ts/dur present & non-null), `at_least_one_aiu`, AIU `ts > 0` / `dur > 0` positivity, and same-thread `no_overlap` of half-open `[ts, ts+dur)` intervals. Malformed top-level JSON raises `TraceParseError`; a parseable-but-invalid trace returns violations (no raise). `valid`/`failing` are independent indicators (Req 7.9).
- `cli.py` / `__main__.py` — `python -m tools.trace_validator <trace.json>`; prints violated checks + offending events, exits non-zero on any violation.

### Trace generator — `scripts/gen_trace.py` *(needs AIU hardware to run)*
- Asserts PrivateUse1 is in `torch.profiler.supported_activities()` (Req 3.3), profiles a small PrivateUse1 workload, and exports `trace.json`. The `torch` import is guarded so the module byte-compiles without torch.

### Tests
- Hypothesis property tests for **Properties 1–5** (200 examples each), tagged per the design.
- Example/edge-case fixtures (golden, empty, all-CPU, overlapping AIU kernels, zero-ts, zero-dur, null name) + CLI tests.
- Hardware-gated generator integration test that **skips** cleanly when torch/AIU are unavailable.
- **24 validator tests pass; generator test skips (no AIU hardware).**


## Testing
```
python3 -m unittest discover -s tools/trace_validator/tests -t .   # 24 tests, OK
python3 -m unittest scripts.test_gen_trace                         # OK (skipped=1)
```

## Note
Independent of #24 (sync pipeline); branched off `main`. Both add `tools/trace_validator/__init__.py`; if #24 merges first a trivial rebase reconciles it.