### PR TITLE
kineto-spyre 2.12: CI smoke workflow — two-job design (PR 4)

### DIFF
--- a/.github/workflows/release-wheel-smoke.yml
+++ b/.github/workflows/release-wheel-smoke.yml
@@ -101,6 +101,7 @@ jobs:
       - name: Build wheel via the real release path
         env:
           LIBAIUPTI_INSTALL_DIR: ${{ env.LIBAIUPTI_INSTALL_DIR }}
+          VERIFY_SUBCOMPONENTS: "1"   # release path: enforce recorded subcomponent versions (Req 9.2-9.5)
         run: ./scripts/build_pytorch.sh
 
       # Req 8.1 (trace) / 8.4: if trace generation fails, this stage fails

--- a/.github/workflows/release-wheel-smoke.yml
+++ b/.github/workflows/release-wheel-smoke.yml
@@ -1,0 +1,118 @@
+name: Release wheel smoke checks
+
+# Req 8.3: the smoke test executes automatically when a change is submitted to
+# the kineto-spyre release branch (push and pull_request targeting release/2.12),
+# and can be launched on demand via workflow_dispatch.
+on:
+  push:
+    branches: ['release/2.12']
+  pull_request:
+    branches: ['release/2.12']
+  workflow_dispatch:
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Job A: GitHub-hosted automated validation that runs NOW, with no AIU
+  # hardware. Lints the build scripts, runs the trace-validator test suite,
+  # exercises the validator CLI against a committed golden trace, and
+  # byte-compiles the trace generator. This provides continuous validation
+  # while the self-hosted AIU runner (Job B) is unavailable.
+  # ---------------------------------------------------------------------------
+  checks:
+    name: Lint + validator checks (GitHub-hosted)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Lint build scripts (bash -n)
+        run: |
+          set -euo pipefail
+          for script in scripts/build_pytorch.sh scripts/build_lib.sh; do
+            if [ -f "$script" ]; then
+              echo "Checking syntax: $script"
+              bash -n "$script"
+            else
+              echo "NOTE: $script not present on this branch yet; skipping."
+            fi
+          done
+
+      - name: Install validator test dependencies
+        run: python -m pip install --upgrade pip hypothesis
+
+      - name: Run trace-validator test suite
+        run: |
+          set -euo pipefail
+          if [ -d tools/trace_validator/tests ]; then
+            python -m unittest discover -s tools/trace_validator/tests -t .
+          else
+            echo "NOTE: tools/trace_validator/tests not present on this branch yet; skipping."
+          fi
+
+      - name: Validate golden sample trace via the validator CLI
+        run: |
+          set -euo pipefail
+          sample=tools/trace_validator/tests/fixtures/sample_trace.json
+          if [ -f "$sample" ] && [ -d tools/trace_validator ]; then
+            # A valid golden trace must validate cleanly (exit 0).
+            python -m tools.trace_validator "$sample"
+          else
+            echo "NOTE: validator package or sample trace not present yet; skipping."
+          fi
+
+      - name: Byte-compile the trace generator
+        run: |
+          set -euo pipefail
+          if [ -f scripts/gen_trace.py ]; then
+            python -m py_compile scripts/gen_trace.py
+          else
+            echo "NOTE: scripts/gen_trace.py not present on this branch yet; skipping."
+          fi
+
+  # ---------------------------------------------------------------------------
+  # Job B: the real release smoke test. Runs on a self-hosted AIU runner with
+  # libaiupti available. This is the end-to-end path (Req 8.1, 8.2, 8.6): it
+  # builds through the real release Build_Script so AIUPTI detection is
+  # genuinely exercised, generates a trace, and validates it. It idles until an
+  # admin registers a runner matching the [self-hosted, aiu] labels.
+  # ---------------------------------------------------------------------------
+  smoke-aiu:
+    name: Real build path smoke test (self-hosted AIU)
+    runs-on: [self-hosted, aiu]        # runner with libaiupti available
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      # Req 8.6 / 4.5: build through the real release path with
+      # LIBAIUPTI_INSTALL_DIR set so AIUPTI_Detection is exercised. A no-AIU
+      # build fails here (Req 8.4) instead of producing a misleading green run.
+      - name: Build wheel via the real release path
+        env:
+          LIBAIUPTI_INSTALL_DIR: ${{ env.LIBAIUPTI_INSTALL_DIR }}
+        run: ./scripts/build_pytorch.sh
+
+      # Req 8.1 (trace) / 8.4: if trace generation fails, this stage fails
+      # directly and the downstream validate step never runs.
+      - name: Install wheel and generate trace
+        run: |
+          set -euo pipefail
+          python3.12 -m pip install dist/*.whl
+          python3.12 scripts/gen_trace.py
+
+      # Req 8.2 / 8.5: assert >= 1 AIU event, no non-concurrent overlap, and
+      # AIU ts > 0 / dur > 0. The validator exits non-zero and names the failed
+      # assertion when any check fails.
+      - name: Validate trace
+        run: python3.12 -m tools.trace_validator trace.json

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 .vscode
 .data
 __pycache__
+
+# Hypothesis property-test example database/cache
+.hypothesis/

--- a/scripts/test_workflow_config.py
+++ b/scripts/test_workflow_config.py
@@ -1,0 +1,133 @@
+"""Config check for the release-wheel smoke workflow (Requirement 8.3).
+
+This test asserts that ``.github/workflows/release-wheel-smoke.yml``:
+
+* triggers on the ``release/2.12`` branch (Req 8.3), so a change submitted to
+  the release branch runs the smoke test automatically;
+* defines a ``smoke-aiu`` job that targets the ``[self-hosted, aiu]`` runner
+  labels (the real release path, Req 8.6); and
+* pins Python 3.12 (the release wheel is ``cp312``).
+
+PyYAML is not part of a stock CPython install and the workflow runs on
+GitHub-hosted runners regardless, so this test does not take a hard dependency
+on it: when ``yaml`` is importable the assertions run against the parsed
+structure, otherwise it falls back to text/regex assertions against the raw
+file. Either path runs on a plain interpreter.
+"""
+
+import os
+import re
+import unittest
+
+WORKFLOW_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    ".github",
+    "workflows",
+    "release-wheel-smoke.yml",
+)
+
+RELEASE_BRANCH = "release/2.12"
+
+try:
+    import yaml  # type: ignore
+
+    _HAVE_YAML = True
+except ImportError:  # pragma: no cover - depends on interpreter environment
+    _HAVE_YAML = False
+
+
+def _read_workflow_text():
+    with open(WORKFLOW_PATH, "r", encoding="utf-8") as handle:
+        return handle.read()
+
+
+class WorkflowConfigStructuredTest(unittest.TestCase):
+    """Assertions against the parsed YAML (only when PyYAML is available)."""
+
+    @classmethod
+    def setUpClass(cls):
+        if not _HAVE_YAML:
+            raise unittest.SkipTest("PyYAML not available; structured checks skipped")
+        with open(WORKFLOW_PATH, "r", encoding="utf-8") as handle:
+            cls.doc = yaml.safe_load(handle)
+
+    def _on(self):
+        # PyYAML parses the bare key ``on:`` as the boolean True, so the
+        # trigger block may live under either ``"on"`` or ``True``.
+        doc = self.doc
+        if "on" in doc:
+            return doc["on"]
+        return doc.get(True)
+
+    def test_triggers_on_release_branch(self):
+        on = self._on()
+        self.assertIsNotNone(on, "workflow defines no trigger block")
+        branches = []
+        for event in ("push", "pull_request"):
+            spec = on.get(event) if isinstance(on, dict) else None
+            if isinstance(spec, dict) and spec.get("branches"):
+                branches.extend(spec["branches"])
+        self.assertIn(
+            RELEASE_BRANCH,
+            branches,
+            "workflow must trigger on the {} branch".format(RELEASE_BRANCH),
+        )
+
+    def test_smoke_job_targets_self_hosted_aiu(self):
+        jobs = self.doc.get("jobs", {})
+        self.assertIn("smoke-aiu", jobs, "missing smoke-aiu job")
+        runs_on = jobs["smoke-aiu"].get("runs-on")
+        self.assertEqual(
+            sorted(runs_on),
+            sorted(["self-hosted", "aiu"]),
+            "smoke-aiu must target the [self-hosted, aiu] labels",
+        )
+
+    def test_python_312_pinned(self):
+        text = _read_workflow_text()
+        self.assertIn("3.12", text, "Python 3.12 must be pinned in the workflow")
+
+
+class WorkflowConfigTextTest(unittest.TestCase):
+    """Text/regex assertions that run on any interpreter (no PyYAML needed)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.text = _read_workflow_text()
+
+    def test_triggers_on_release_branch(self):
+        # Branch appears (quoted or bare) in a branches: list under push/pull_request.
+        self.assertRegex(
+            self.text,
+            r"branches:\s*\[\s*['\"]?{}['\"]?\s*\]".format(re.escape(RELEASE_BRANCH)),
+            "workflow must list the {} branch in a branches filter".format(
+                RELEASE_BRANCH
+            ),
+        )
+
+    def test_has_push_and_pull_request_triggers(self):
+        self.assertRegex(self.text, r"(?m)^\s*push:")
+        self.assertRegex(self.text, r"(?m)^\s*pull_request:")
+
+    def test_smoke_job_targets_self_hosted_aiu(self):
+        self.assertRegex(
+            self.text,
+            r"(?m)^\s*smoke-aiu:",
+            "missing smoke-aiu job",
+        )
+        self.assertRegex(
+            self.text,
+            r"runs-on:\s*\[\s*self-hosted\s*,\s*aiu\s*\]",
+            "smoke-aiu must target the [self-hosted, aiu] labels",
+        )
+
+    def test_python_312_pinned(self):
+        self.assertRegex(
+            self.text,
+            r"python-version:\s*['\"]?3\.12['\"]?",
+            "Python 3.12 must be pinned via setup-python",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/trace_validator/tests/fixtures/sample_trace.json
+++ b/tools/trace_validator/tests/fixtures/sample_trace.json
@@ -1,0 +1,40 @@
+{
+  "traceEvents": [
+    {
+      "name": "aten::randn",
+      "ph": "X",
+      "ts": 100,
+      "dur": 50,
+      "pid": 1,
+      "tid": 1,
+      "cat": "cpu_op"
+    },
+    {
+      "name": "aten::matmul",
+      "ph": "X",
+      "ts": 200,
+      "dur": 50,
+      "pid": 1,
+      "tid": 1,
+      "cat": "cpu_op"
+    },
+    {
+      "name": "aiu_randn_kernel",
+      "ph": "X",
+      "ts": 160,
+      "dur": 40,
+      "pid": 1,
+      "tid": 2,
+      "cat": "aiu"
+    },
+    {
+      "name": "aiu_matmul_kernel",
+      "ph": "X",
+      "ts": 220,
+      "dur": 30,
+      "pid": 1,
+      "tid": 2,
+      "cat": "privateuse1"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

PR 4 of the kineto-spyre 2.12 release pipeline — Component 6 (CI Smoke Test). Replaces the lint-only workflow with a **two-job** design (the agreed "option 3") so automated validation runs **now** on GitHub-hosted runners, while the real end-to-end build path is wired and ready for when a self-hosted AIU runner is registered.

### Job `checks` — GitHub-hosted (`ubuntu-latest`, Python 3.12), runs today
- `bash -n` lint of `build_pytorch.sh` / `build_lib.sh`
- runs the trace-validator test suite (incl. the Hypothesis property tests)
- validates a committed golden sample trace via `python -m tools.trace_validator` (exit 0)
- byte-compiles `gen_trace.py`

Steps that depend on code arriving in #25 (validator) / #26 (build scripts) guard-skip gracefully until those merge, then run for real.

### Job `smoke-aiu` — `[self-hosted, aiu]`, the real release path (Req 8.1/8.2/8.6)
- builds via `./scripts/build_pytorch.sh` with `LIBAIUPTI_INSTALL_DIR` (exercises AIUPTI detection)
- installs the wheel, runs `gen_trace.py`, validates ≥1 AIU event / no non-concurrent overlap / AIU ts>0 / dur>0
- build/trace stage failures fail directly (Req 8.4); assertion failures are named (Req 8.5)
- **idles until an admin registers an AIU runner** matching the labels

### Triggers (Req 8.3)
`push` + `pull_request` on `release/2.12`, plus `workflow_dispatch`.

### Tests
- `scripts/test_workflow_config.py` — asserts the release-branch trigger, the `[self-hosted, aiu]` labels, and the Python 3.12 pin (no hard PyYAML dependency). Passes under 3.12.
- The committed `sample_trace.json` was verified to validate clean against the real validator.

Requirements: 8.1–8.6.

## Dependencies / merge order
The `checks` job runs the validator (#25) and lints the build scripts (#26); the `smoke-aiu` job calls `build_pytorch.sh` (#26) and the validator (#25). Merge **#25 and #26 before #26**… i.e. this PR is the integrating one — merge after #25 and #26. Until then the dependent steps guard-skip.

## Self-hosted runner note
`runs-on: [self-hosted, aiu]` is a label, not a provisioned machine. An IBM `kineto-spyre` admin must register an AIU machine (with `libaiupti` + `LIBAIUPTI_INSTALL_DIR`) as a self-hosted runner with the `aiu` label for `smoke-aiu` to execute.