### PR TITLE
Add cycles_ts array metadata to kernel and memcpy trace events

### DIFF
--- a/libkineto/src/plugin/aiupti/AiuptiActivityHandlers.cpp
+++ b/libkineto/src/plugin/aiupti/AiuptiActivityHandlers.cpp
@@ -271,6 +271,10 @@ void AiuptiActivityProfilerSession::handleKernelActivity(
   kernel_activity->addMetadataQuoted("context",
                                      std::to_string(activity->context_id));
   kernel_activity->addMetadata("correlation", activity->correlation_id);
+  kernel_activity->addMetadata("cycles_ts",
+      fmt::format("[{}, {}, {}, {}, {}]",
+          activity->cycles_ts1, activity->cycles_ts2,
+          activity->cycles_ts3, activity->cycles_ts4, activity->cycles_ts5));
 
   recordStream(kernel_activity->device, kernel_activity->resource);
 
@@ -386,6 +390,10 @@ void AiuptiActivityProfilerSession::handleMemcpyActivity(
   memcpy_activity->addMetadata("memory operation id", activity->copy_kind);
   memcpy_activity->addMetadata("bytes", activity->bytes);
   memcpy_activity->addMetadata("memory bandwidth (GB/s)", bandwidth(activity));
+  memcpy_activity->addMetadata("cycles_ts",
+      fmt::format("[{}, {}, {}, {}, {}]",
+          activity->cycles_ts1, activity->cycles_ts2,
+          activity->cycles_ts3, activity->cycles_ts4, activity->cycles_ts5));
 
   if (memcpy_activity->resource == getBaseResourceId(activity)) {
     recordMemoryStream(


### PR DESCRIPTION
## Summary
- Surface TS1-TS5 device cycle counters as a JSON array in trace output
- Added to both handleKernelActivity() and handleMemcpyActivity()
- Uses single array key \`cycles_ts: [ts1, ts2, ts3, ts4, ts5]\`

## Related
- Issue [#2152](https://github.com/torch-spyre/torch-spyre/issues/2152)
- Companion PR on libaiupti: [adds cycles_ts1-5 fields to ActivityCompute/ActivityMemcpy structs](https://github.ibm.com/ai-chip-toolchain/libaiupti/commit/862b195bcb0beb3197ca983c3a68562fbaa600f6)

## Test plan
- [ ] Run profiled workload, verify kernel events show non-zero cycles_ts values
- [ ] Verify memcpy events show cycles_ts (zeros until flex-side propagation is merged)
- [ ] Confirm trace loads correctly in Chrome Trace Viewer and Perfetto