### PR TITLE
aiupti plugin: map SPYRE_CODE_HOST_COMPUTE and backfilled cbids to names

### DIFF
--- a/libkineto/src/plugin/aiupti/AiuptiActivityHandlers.cpp
+++ b/libkineto/src/plugin/aiupti/AiuptiActivityHandlers.cpp
@@ -174,6 +174,14 @@ inline std::string runtimeCbidName(AIUpti_runtime_api_trace_cbid cbid) {
       return "aiuClockCalibration";
     case AIUPTI_RUNTIME_TRACE_CBID_COMPILE_GRAPH:
       return "aiuCompileGraph";
+    case AIUPTI_RUNTIME_TRACE_CBID_PARSE_RESPONSE:
+      return "aiuParseResponse";
+    case AIUPTI_RUNTIME_TRACE_CBID_ISSUE_CALLBACK:
+      return "aiuIssueCallback";
+    case AIUPTI_RUNTIME_TRACE_CBID_VERIFY_ASYC_MSGS:
+      return "aiuVerifyAsyncMsgs";
+    case AIUPTI_RUNTIME_TRACE_CBID_SPYRE_CODE_HOST_COMPUTE:
+      return "aiuSpyreCodeHostCompute";
     default:
       break;
   }


### PR DESCRIPTION
## Summary

Maps the new and backfilled CBIDs (38-41) to human-readable trace event names in `runtimeCbidName()`:

| CBID | Enum | Display Name |
|------|------|-------------|
| 38 | `AIUPTI_RUNTIME_TRACE_CBID_PARSE_RESPONSE` | `aiuParseResponse` |
| 39 | `AIUPTI_RUNTIME_TRACE_CBID_ISSUE_CALLBACK` | `aiuIssueCallback` |
| 40 | `AIUPTI_RUNTIME_TRACE_CBID_VERIFY_ASYC_MSGS` | `aiuVerifyAsyncMsgs` |
| 41 | `AIUPTI_RUNTIME_TRACE_CBID_SPYRE_CODE_HOST_COMPUTE` | `aiuSpyreCodeHostCompute` |

These names appear in the `"name"` field of Chrome trace events (category: `privateuse1_runtime`).

### Companion PRs

- **flex:** Instrumentation source — `ai-chip-toolchain/flex` branch `profiler/jobplan-step-logging`
- **libaiupti:** CBID enum sync — `ai-chip-toolchain/libaiupti` branch `profiler/jobplan-step-logging`

## Overhead Analysis

Minimal runtime overhead. Compared spyre-perf-suite numbers generated by this branch v/s main branch.

## Trace Evidence

Confirmed in PyTorch profiler output:
```json
{"name": "aiuSpyreCodeHostCompute", "cat": "privateuse1_runtime", "dur": 256.784}
{"name": "aiuDataConvert", "cat": "privateuse1_runtime", "dur": 150.415}
```

[mean_mul_softmax_trace.json.txt](https://github.com/user-attachments/files/30541173/mean_mul_softmax_trace.json.txt)


## Test Plan

- [x] New CBID names appear correctly in exported Chrome trace JSON
- [x] Existing CBID names unchanged (no regression)
- [x] Verified with mean_mul_softmax workload on hardware